### PR TITLE
Cancel sumVotes interval on navigation

### DIFF
--- a/public/js/controllers/editElectionCtrl.js
+++ b/public/js/controllers/editElectionCtrl.js
@@ -64,6 +64,10 @@ function($scope, $interval, electionService, adminElectionService, alertService)
             });
     }
 
+    $scope.$on('$destroy', function() {
+        if (countInterval) $interval.cancel(countInterval);
+    });
+
     $scope.toggleCount = function() {
         $scope.showCount = !$scope.showCount;
         if ($scope.showCount) {


### PR DESCRIPTION
So that if you navigate away from the edit election page it won't try to get the vote results anymore.
