### PR TITLE
Joined "all" and "install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ FRONTEND_FILES = $(shell find public -name "*.js" -not -name "*.min.js")
 BACKEND_FILES = $(shell find app -name "*.js")
 CUCUMBER_FILES = $(shell find features -name "*.js" -or -name "*.feature")
 
-all: node_modules public/main.css
-
-install: node_modules public/lib
+install: node_modules public/lib public/main.css
 
 node_modules: package.json
 	@npm install


### PR DESCRIPTION
I can't find any reasons to keep both `make install` and `make all`. `make install` does not compress `.styl`-files. This fix will make `make install` sufficient to install both npm-packages, bower and compress styles.