### PR TITLE
Skip selenium and use the webdriver with chrome directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ install: node_modules public/lib
 node_modules: package.json
 	@npm install
 
+webdriver:
+	$(WEBDRIVER_MANAGER) update --standalone false
+
 public/lib: bower.json
 	@$(BOWER) install --allow-root
 
-selenium:
-	$(WEBDRIVER_MANAGER) update
-
-protractor: selenium all
+protractor: webdriver all
 	NODE_ENV=test MONGO_URL=$(TEST_DB) $(PROTRACTOR) ./features/protractor-conf.js
 
 lint: $(FRONTEND_FILES) $(BACKEND_FILES) $(CUCUMBER_FILES)

--- a/features/protractor-conf.js
+++ b/features/protractor-conf.js
@@ -6,6 +6,7 @@ exports.config = {
     specs: ['*.feature'],
     framework: 'custom',
     frameworkPath: require.resolve('protractor-cucumber-framework'),
+    directConnect: true,
     cucumberOpts: {
         require: ['step_definitions/*.js', 'support/*.js'],
         backtrace: true,


### PR DESCRIPTION
>Protractor can test directly against Chrome and Firefox without using a Selenium Server. To use this, in your config file set directConnect: true.

>directConnect: true - Your test script communicates directly Chrome Driver or Firefox Driver, bypassing any Selenium Server. If this is true, settings for seleniumAddress and seleniumServerJar will be ignored. If you attempt to use a browser other than Chrome or Firefox an error will be thrown.

>The advantage of directly connecting to browser drivers is that your test scripts may start up and run faster.

https://angular.github.io/protractor/#/server-setup#connecting-directly-to-browser-drivers