### PR TITLE
Add a copy election button

### DIFF
--- a/app/views/partials/admin/editElection.pug
+++ b/app/views/partials/admin/editElection.pug
@@ -34,3 +34,6 @@
                     ng-if='!election.active',
                     ng-class='{"alone": election.active}')
                     | {{showCount ? 'Skjul resultat': 'Vis resultat'}}
+                button.toggle-show.btn.btn-default(type='button', ng-click='copyElection()',
+                    ng-if='!election.active')
+                    | Kopier avstemning

--- a/client/controllers/createElectionCtrl.js
+++ b/client/controllers/createElectionCtrl.js
@@ -1,8 +1,14 @@
 module.exports = ['$scope', '$location', 'adminElectionService', 'alertService',
 function($scope, $location, adminElectionService, alertService) {
-    $scope.election = {
-        alternatives: [{}]
-    };
+    var existingElection = $location.search().election;
+    if (existingElection) {
+        $scope.election = JSON.parse(existingElection);
+    } else {
+        $scope.election = {
+            alternatives: [{}]
+        };
+    }
+
 
     $scope.createElection = function(election) {
         adminElectionService.createElection(election)

--- a/client/controllers/editElectionCtrl.js
+++ b/client/controllers/editElectionCtrl.js
@@ -1,5 +1,6 @@
-module.exports = ['$scope', '$interval', 'userService', 'adminElectionService', 'alertService',
-function($scope, $interval, userService, adminElectionService, alertService) {
+module.exports = ['$scope', '$interval', '$location',
+'userService', 'adminElectionService', 'alertService',
+function($scope, $interval, $location, userService, adminElectionService, alertService) {
     $scope.newAlternative = {};
     $scope.election = null;
     $scope.showCount = false;
@@ -110,5 +111,21 @@ function($scope, $interval, userService, adminElectionService, alertService) {
         if ($scope.showCount) {
             getCount();
         }
+    };
+
+    $scope.copyElection = function() {
+        var alternatives = $scope.election.alternatives.map(function(alternative) {
+            return { description: alternative.description };
+        });
+
+        var election = {
+            title: $scope.election.title,
+            description: $scope.election.description,
+            alternatives: alternatives
+        };
+
+        $location
+            .path('/admin/create_election')
+            .search({ election: JSON.stringify(election) });
     };
 }];


### PR DESCRIPTION
Adds a frontend button to the admin election page that copies the data of an existing election into the new election form, so that an election easily can be repeated with one alternative less or similar.

Fixes #115.