### PR TITLE
baudrate is now baudRate https://web.dev/serial/

### DIFF
--- a/client/services/cardKeyService.js
+++ b/client/services/cardKeyService.js
@@ -79,7 +79,7 @@ module.exports = [
           try {
             const port = await $window.navigator.serial.requestPort({});
 
-            await port.open({ baudrate: 9600 });
+            await port.open({ baudRate: 9600 });
             $rootScope.serialWriter = port.writable.getWriter();
             $rootScope.serialReader = port.readable.getReader();
           } catch (e) {


### PR DESCRIPTION
So they decided to change baudrate to baudRate in our experimental feature :shock:﻿

old
![image](https://user-images.githubusercontent.com/23152018/99287361-6e610b80-283a-11eb-9af1-4a228ec55a1d.png)

new
![image](https://user-images.githubusercontent.com/23152018/99287323-630de000-283a-11eb-8e1b-c15ed70dd1aa.png)

