### PR TITLE
Make the QR use a pulse animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ Please check that the USB card reader is connected. When prompted for permission
 
 ### Serial permissions (Linux)
 
-When using the card readers on a linux based system **google-chrome** there can be permission problems. Chrome needs access to the ports,
-and often the ports are controlled by another group, so chrome cannot use them. Therefore you must do one of the following:
+When using the card readers on a linux based system there can be permission problems with **google-chrome**. Chrome needs access to the ports, and often the ports are controlled by another group, so chrome cannot use them. Therefore you must do one of the following:
 
 1. Run google-chrome as `root`
-  ```sh
-  $ sudo google-chrome
-  ```
 
-   **OR**
+```sh
+$ sudo google-chrome
+```
+
+**OR**
 
 2. Add your user to the `dialout` group.
    - Check what group the tty(USBPORT) is:

--- a/app/views/partials/moderator/serial_error.pug
+++ b/app/views/partials/moderator/serial_error.pug
@@ -1,8 +1,22 @@
-.jumbotron.center.text-center
-  h3 Serial error
-  p Click on any tab above to start a permission request.
-  br
-  p Make sure you have enabled Experimental Web Platform features and are using Google Chrome. Experimental features can be enabled by navigating to:
-    b chrome://flags/#enable-experimental-web-platform-features
-  br
-  p Please check that the USB card reader is connected. When prompted for permissions, please select the card reader (CP210x).
+.jumbotron.center
+  .text-center
+    h3 Serial error
+    h4 The card reader is not fully linked with the browser
+    hr
+    div
+      a(href='/moderator/create_user') Click here to start a permission request.
+
+  b Tips
+  hr
+  h5 1) Make sure you have enabled Experimental Web Platform features and are using Google Chrome. Learn how to enable this feature by going to#{' '}
+    a(
+      href='https://github.com/webkom/vote#using-the-card-readers',
+      target='_blank'
+    ) README.md
+  h5 2) Please check that the USB card reader is connected. When prompted for permissions, please select the card reader (CP210x).
+  h5 3) If you are running Linux, run Google Chrome as root to gain access to tty. See#{' '}
+    a(
+      href='https://github.com/webkom/vote#serial-permissions-linux',
+      target='_blank'
+    ) README.md
+  hr

--- a/app/views/partials/moderator/showqr.pug
+++ b/app/views/partials/moderator/showqr.pug
@@ -1,7 +1,7 @@
 .row
   .text-center.image-block
     h3 Scan QR-Kode!
-    img#IdName.className(
+    img.animated-qr(
       ng-attr-src='{{ qrdata }}',
       alt='Image QR-kode',
       width='600',

--- a/client/styles/admin.styl
+++ b/client/styles/admin.styl
@@ -91,3 +91,17 @@ form.add-alternative
 .animated-alert.ng-leave.ng-leave-active
     max-height: 0;
     opacity: 0;
+
+@keyframes zoom {
+    0% {
+        transform:scale(1);
+    }
+    100% {
+        transform:scale(0.3);
+    }
+}
+.animated-qr
+    animation-name: zoom
+    animation-duration: 4s
+    animation-iteration-count: infinite
+    animation-direction: alternate


### PR DESCRIPTION
Some iPhone users need the QR quite far away, while some android users need the QR code very close.
This fixes that:
> (it's actually 60fps, but the Gif looks like shit)


![ezgif-6-e2201ebb5fb6](https://user-images.githubusercontent.com/23152018/99293571-25618500-2843-11eb-9a25-b2e70b614d28.gif)
