### PR TITLE
Move logo out of header

### DIFF
--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -23,11 +23,8 @@ html(ng-app='voteApp')
     header
       .container
         .row.header: .col-xs-12
-          //img(src=LOGO_SRC)
-          span
-            | v
-            img(src=LOGO_SRC)
-            | te
+          img(src=LOGO_SRC)
+          span vote
 
         .row: block navbar
 

--- a/client/styles/main.styl
+++ b/client/styles/main.styl
@@ -55,6 +55,7 @@ header
     padding-top 50px
 
     img
+        margin-right 15px
         width 35px
 
 footer


### PR DESCRIPTION
This reverts commit af9c893bee0c8a6e1c7c64ed65d60d7d53046441.

Fun idea, but it doesn't make sense when people other than Abakus want to use the application.
