### PR TITLE
STV Core algorithm implementation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+build/Release
+node_modules
+*.map
+dist
+public
+app/stv/stv.js

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -170,17 +170,6 @@ class DuplicateUsernameError extends Error {
 
 exports.DuplicateUsernameError = DuplicateUsernameError;
 
-class StrictWithoutOneSeatError extends Error {
-  constructor() {
-    super();
-    this.name = 'StrictWithoutOneSeatError';
-    this.message = 'Cannot have a strict election with more then one seat.';
-    this.status = 400;
-  }
-}
-
-exports.StrictWithoutOneSeatError = StrictWithoutOneSeatError;
-
 exports.handleError = (res, err, status) => {
   const statusCode = status || err.status || 500;
   return res.status(statusCode).json(

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -170,6 +170,17 @@ class DuplicateUsernameError extends Error {
 
 exports.DuplicateUsernameError = DuplicateUsernameError;
 
+class StrictWithoutOneSeatError extends Error {
+  constructor() {
+    super();
+    this.name = 'StrictWithoutOneSeatError';
+    this.message = 'Cannot have a strict election with more then one seat.';
+    this.status = 400;
+  }
+}
+
+exports.StrictWithoutOneSeatError = StrictWithoutOneSeatError;
+
 exports.handleError = (res, err, status) => {
   const statusCode = status || err.status || 500;
   return res.status(statusCode).json(

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -114,12 +114,12 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
 
     for (let i in votes) {
       // @const { Vote } vote - The vote for this loop
-      const vote = votes[i];
+      const vote = Object.create(votes[i]);
 
       // @const { Alternative } currentAlternative - We always count the first value (priorities[0])
       // because there is a mutation step that removed values that are "done". These are values
       // connected to candidates that have either won or been eliminated from the election.
-      const currentAlternative = vote.priorities[0];
+      const currentAlternative = Object.create(vote.priorities[0]);
 
       // Use the alternatives description as key in the counts, and add one for each count
       counts[currentAlternative.description] =
@@ -147,7 +147,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
     // Loop over the different alternatives
     for (let i in alternatives) {
       // @const { Alternative } alternative - Get an alternative
-      const alternative = alternatives[i];
+      const alternative = Object.create(alternatives[i]);
       // @const { float } voteCount - Find the number number of votes for this alternative
       const voteCount = counts[alternative.description] || 0;
 
@@ -173,7 +173,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
         // Find the done Votes
         for (let i in votes) {
           // @const { Vote } vote - The vote for this loop
-          const vote = votes[i];
+          const vote = Object.create(votes[i]);
 
           // Votes that have the winning alternative as their first pick
           if (vote.priorities[0]._id === alternative._id) doneVotes[i] = {};
@@ -207,10 +207,10 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
       // Go through all done votes
       for (let i in doneVotes) {
         // @const { Vote } vote - The vote for this loop
-        const vote = votes[i];
+        const vote = Object.create(votes[i]);
 
         // @const { Alternative } alternative - Take the first choice of the done vote
-        const alternative = vote.priorities[0];
+        const alternative = Object.create(vote.priorities[0]);
 
         // @const { float } fraction - Find the excess fraction for this alternative
         const fraction = excessFractions[alternative._id] || 0;

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -1,370 +1,189 @@
-const errors = require('../errors');
-
-/** Types used in this file
- * type STV = {
- *   result: STVResult;
- *   log: STVEvent[];
- *   thr: number;
- *   seats: number;
- *   voteCount: number;
- *   useStrict: boolean;
- * };
- *
- * type Alternative = {
- *   _id: string;
- *   description: string;
- *   election: string;
- * };
- *
- * type Vote = {
- *   _id: string;
- *   priorities: Alternative[];
- *   hash: string;
- *   weight: number;
- * };
- *
- * type STVEvent =
- *   | {
- *       action: 'ITERATION';
- *       iteration: number;
- *       winners: Alternative[];
- *       alternatives: Alternative[];
- *       votes: Vote[];
- *       counts: { [key: string]: number };
- *     }
- *   | {
- *       action: 'WIN';
- *       alternative: Alternative;
- *       voteCount: number;
- *     }
- *   | {
- *       action: 'ELIMINATE';
- *       alternative: Alternative;
- *       minScore: number;
- *     }
- *   | {
- *       action: 'MULTI_TIE_ELIMINATIONS';
- *       alternatives: Alternative[];
- *       minScore: number;
- *     }
- *   | {
- *       action: 'TIE';
- *       description: string;
- *     };
- * type STVResult =
- *   | {
- *       status: 'RESOLVED';
- *       winners: Alternative[];
- *     }
- *   | {
- *       status: 'UNRESOLVED';
- *       winners: Alternative[];
- *     };
- */
-
-/**
- * The Droop qouta https://en.wikipedia.org/wiki/Droop_quota
- * @param { Vote[] } votes - All votes for the election
- * @param { int } seats - The number of seats in this election
- * @param { boolean } useStrict - Sets the threshold to 67% no matter what
- *
- * @return { int } The amount votes needed to be elected
- */
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const cloneDeep = require("lodash/cloneDeep");
+var Action;
+(function (Action) {
+    Action["iteration"] = "ITERATION";
+    Action["win"] = "WIN";
+    Action["eliminate"] = "ELIMINATE";
+    Action["multi_tie_eliminations"] = "MULTI_TIE_ELIMINATIONS";
+    Action["tie"] = "TIE";
+})(Action || (Action = {}));
+var Status;
+(function (Status) {
+    Status["resolved"] = "RESOLVED";
+    Status["unresolved"] = "UNRESOLVED";
+})(Status || (Status = {}));
 const winningThreshold = (votes, seats, useStrict) => {
-  if (useStrict) {
-    return Math.floor((2 * votes.length) / 3) + 1;
-  }
-  return Math.floor(votes.length / (seats + 1) + 1);
+    if (useStrict) {
+        return Math.floor((2 * votes.length) / 3) + 1;
+    }
+    return Math.floor(votes.length / (seats + 1) + 1);
 };
-
-// Epsilon value used in comparisons of floating point errors. See dataset5.js.
 const EPSILON = 0.000001;
-
-/**
- * Will calculate the election result using Single Transferable Vote
- * @param { Vote[] } votes - All votes for the election
- * @param { Alternative[] } alternatives - All possible alternatives for the election
- * @param { int } seats - The number of seats in this election. Default 1
- * @param { boolean } useStrict - This election will require a qualified majority. Default false
- *
- * @return { STV } The full election, including result, log and threshold value
- */
-exports.calculateWinnerUsingSTV = (
-  inputVotes,
-  inputAlternatives,
-  seats = 1,
-  useStrict = false
-) => {
-  // Check that this election does not violate the strict constraint
-  if (useStrict && seats !== 1) throw new errors.StrictWithoutOneSeatError();
-
-  // @let { STVEvent[] } log - Will hold the log for the entire election
-  let log = [];
-
-  // Stringify and clean the votes
-  let votes = inputVotes.map((vote) => ({
-    _id: String(vote._id),
-    priorities: JSON.parse(JSON.stringify(vote.priorities)),
-    hash: vote.hash,
-    weight: 1,
-  }));
-
-  // Stringify and clean the alternatives
-  let alternatives = JSON.parse(JSON.stringify(inputAlternatives));
-
-  // @const { int } thr - The threshold value needed to win
-  const thr = winningThreshold(votes, seats, useStrict);
-
-  // @let { Alternative[] } winners - Winners for the election
-  let winners = [];
-
-  // @let { int } iteration - The election is a while loop, and with each iteration
-  // we count the number of first place votes each candidate has.
-  let iteration = 0;
-  while (votes.length > 0 && iteration < 100) {
-    iteration += 1;
-
-    // Remove empty votes, this happens after the threshold is calculated
-    // in order to preserve "blank votes"
-    votes = votes.filter((vote) => vote.priorities.length > 0);
-
-    // @let { [key: string]: float } counts - Dict with the counts for each candidate
-    let counts = {};
-
-    for (let i in votes) {
-      // @const { Vote } vote - The vote for this loop
-      const vote = JSON.parse(JSON.stringify(votes[i]));
-
-      // @const { Alternative } currentAlternative - We always count the first value (priorities[0])
-      // because there is a mutation step that removes values that are "done". These are values
-      // connected to candidates that have either won or been eliminated from the election.
-      const currentAlternative = JSON.parse(JSON.stringify(vote.priorities[0]));
-
-      // Use the alternatives description as key in the counts, and add one for each count
-      counts[currentAlternative.description] =
-        vote.weight + (counts[currentAlternative.description] || 0);
-    }
-
-    // Push Iteration to log
-    log.push({
-      action: 'ITERATION',
-      iteration,
-      winners: winners.slice(),
-      counts: handleFloatsInOutput(counts),
-    });
-
-    // @let { [key: string]: {} } roundWinner - Dict of winners
-    let roundWinners = {};
-    // @let { [key: string]: float } excessFractions - Dict of excess fractions per key
-    let excessFractions = {};
-    // @let { [key: string]: {} } doneVotes - Dict of done votes
-    let doneVotes = {};
-
-    // Loop over the different alternatives
-    for (let i in alternatives) {
-      // @const { Alternative } alternative - Get an alternative
-      const alternative = JSON.parse(JSON.stringify(alternatives[i]));
-      // @const { float } voteCount - Find the number of votes for this alternative
-      const voteCount = counts[alternative.description] || 0;
-
-      // If an alternative has enough votes, add them as round winner
-      // Due to JavaScript float precision errors this voteCount is checked with a range
-      if (voteCount >= thr - EPSILON) {
-        // Calculate the excess fraction of votes, above the threshold
-        excessFractions[alternative._id] = (voteCount - thr) / voteCount;
-
-        // Add the alternatives ID to the dict of winners this round
-        roundWinners[alternative._id] = {};
-
-        // Push the whole alternative to the list of new winners
-        winners.push(alternative);
-
-        // Add the WIN action to the iteration log
-        log.push({
-          action: 'WIN',
-          alternative,
-          voteCount: Number(voteCount.toFixed(4)),
-        });
-
-        // Find the done Votes
-        for (let i in votes) {
-          // @const { Vote } vote - The vote for this loop
-          const vote = JSON.parse(JSON.stringify(votes[i]));
-
-          // Votes that have the winning alternative as their first pick
-          if (vote.priorities[0]._id === alternative._id) doneVotes[i] = {};
+exports.calculateWinnerUsingSTV = (inputVotes, inputAlternatives, seats = 1, useStrict = false) => {
+    const log = [];
+    let votes = inputVotes.map((vote) => ({
+        _id: String(vote._id),
+        priorities: vote.priorities.map((vote) => ({
+            _id: String(vote._id),
+            description: vote.description,
+            election: String(vote._id),
+        })),
+        hash: vote.hash,
+        weight: 1,
+    }));
+    let alternatives = inputAlternatives.map((alternative) => ({
+        _id: String(alternative._id),
+        description: alternative.description,
+        election: String(alternative._id),
+    }));
+    const thr = winningThreshold(votes, seats, useStrict);
+    const winners = [];
+    let iteration = 0;
+    while (votes.length > 0 && iteration < 100) {
+        iteration += 1;
+        votes = votes.filter((vote) => vote.priorities.length > 0);
+        const counts = {};
+        for (const i in votes) {
+            const vote = cloneDeep(votes[i]);
+            const currentAlternative = cloneDeep(vote.priorities[0]);
+            counts[currentAlternative.description] =
+                vote.weight + (counts[currentAlternative.description] || 0);
         }
-      }
-    }
-
-    // @let { [key: string]: {} } doneAlternatives - Have won or been eliminated
-    let doneAlternatives = {};
-
-    // @let { Vote[] } nextRoundVotes - The votes that will go on to the next round
-    let nextRoundVotes = [];
-
-    // If there are new winners this round
-    if (Object.keys(roundWinners).length > 0) {
-      // Check STV can terminate and return the RESOLVED winners
-      if (winners.length === seats) {
-        return {
-          result: { status: 'RESOLVED', winners },
-          log,
-          thr,
-          seats,
-          voteCount: inputVotes.length,
-          useStrict,
+        const iterationLog = {
+            action: Action.iteration,
+            iteration,
+            winners: winners.slice(),
+            counts: handleFloatsInOutput(counts),
         };
-      }
-
-      // Set the done alternatives as the roundwinners
-      doneAlternatives = roundWinners;
-
-      // The next rounds votes are votes that are not done.
-      nextRoundVotes = votes.filter((_, i) => !doneVotes[i]);
-
-      // Go through all done votes
-      for (let i in doneVotes) {
-        // @const { Vote } vote - The vote for this loop
-        const vote = JSON.parse(JSON.stringify(votes[i]));
-
-        // @const { Alternative } alternative - Take the first choice of the done vote
-        const alternative = JSON.parse(JSON.stringify(vote.priorities[0]));
-
-        // @const { float } fraction - Find the excess fraction for this alternative
-        const fraction = excessFractions[alternative._id] || 0;
-
-        // If the fraction is 0 (meaning no votes should be transferred) or if the vote
-        // has no more priorities (meaning it's exhausted) we can continue without transfer
-        if (fraction === 0 || vote.priorities.length === 1) continue;
-
-        // Fractional transfer. We mutate the weight for these votes by a fraction
-        vote['weight'] = vote.weight * fraction;
-        // Push the mutated votes to the list of votes to be processed in the next iteration
-        nextRoundVotes.push(vote);
-      }
-    } else {
-      // Find the lowest score
-      const minScore = Math.min(
-        ...alternatives.map(
-          (alternative) => counts[alternative.description] || 0
-        )
-      );
-
-      // Find the candidates with the lowest score
-      const minAlternatives = alternatives.filter(
-        (alternative) =>
-          (counts[alternative.description] || 0) <= minScore + EPSILON
-      );
-
-      // There is a tie for eliminating candidates. Per Scottish STV we must look at the previous rounds
-      if (minAlternatives.length > 1) {
-        let reverseIteration = iteration;
-
-        // Log the Tie
-        log.push({
-          action: 'TIE',
-          description: `There are ${
-            minAlternatives.length
-          } candidates with a score of ${Number(
-            minScore.toFixed(4)
-          )} at iteration ${reverseIteration}`,
+        log.push(iterationLog);
+        const roundWinners = {};
+        const excessFractions = {};
+        const doneVotes = {};
+        for (const i in alternatives) {
+            const alternative = cloneDeep(alternatives[i]);
+            const voteCount = counts[alternative.description] || 0;
+            if (voteCount >= thr - EPSILON) {
+                excessFractions[alternative._id] = (voteCount - thr) / voteCount;
+                roundWinners[alternative._id] = {};
+                winners.push(alternative);
+                const winLog = {
+                    action: Action.win,
+                    alternative,
+                    voteCount: Number(voteCount.toFixed(4)),
+                };
+                log.push(winLog);
+                for (const i in votes) {
+                    const vote = cloneDeep(votes[i]);
+                    if (vote.priorities[0]._id === alternative._id)
+                        doneVotes[i] = {};
+                }
+            }
+        }
+        let doneAlternatives = {};
+        let nextRoundVotes = [];
+        if (Object.keys(roundWinners).length > 0) {
+            if (winners.length === seats) {
+                return {
+                    result: { status: Status.resolved, winners },
+                    log,
+                    thr,
+                    seats,
+                    voteCount: inputVotes.length,
+                    useStrict,
+                };
+            }
+            doneAlternatives = roundWinners;
+            nextRoundVotes = votes.filter((_, i) => !doneVotes[i]);
+            for (const i in doneVotes) {
+                const vote = cloneDeep(votes[i]);
+                const alternative = cloneDeep(vote.priorities[0]);
+                const fraction = excessFractions[alternative._id] || 0;
+                if (fraction === 0 || vote.priorities.length === 1)
+                    continue;
+                vote['weight'] = vote.weight * fraction;
+                nextRoundVotes.push(vote);
+            }
+        }
+        else {
+            const minScore = Math.min(...alternatives.map((alternative) => counts[alternative.description] || 0));
+            const minAlternatives = alternatives.filter((alternative) => (counts[alternative.description] || 0) <= minScore + EPSILON);
+            if (minAlternatives.length > 1) {
+                let reverseIteration = iteration;
+                const tieObject = {
+                    action: Action.tie,
+                    description: `There are ${minAlternatives.length} candidates with a score of ${Number(minScore.toFixed(4))} at iteration ${reverseIteration}`,
+                };
+                log.push(tieObject);
+                while (reverseIteration >= 1) {
+                    const logObject = log.find((entry) => entry.iteration === reverseIteration);
+                    const iterationMinScore = Math.min(...minAlternatives.map((a) => logObject.counts[a.description] || 0));
+                    const iterationMinAlternatives = minAlternatives.filter((alternative) => (logObject.counts[alternative.description] || 0) <=
+                        iterationMinScore + EPSILON);
+                    if (reverseIteration === 1 && iterationMinAlternatives.length > 1) {
+                        const backTrackFailed = {
+                            action: Action.tie,
+                            description: 'The backward checking went to iteration 1 without breaking the tie',
+                        };
+                        log.push(backTrackFailed);
+                        const multiTieElem = {
+                            action: Action.multi_tie_eliminations,
+                            alternatives: iterationMinAlternatives,
+                            minScore: Number(minScore.toFixed(4)),
+                        };
+                        log.push(multiTieElem);
+                        iterationMinAlternatives.forEach((alternative) => (doneAlternatives[alternative._id] = {}));
+                        break;
+                    }
+                    reverseIteration--;
+                    if (iterationMinAlternatives.length > 1)
+                        continue;
+                    const minAlternative = iterationMinAlternatives[0];
+                    if (minAlternative) {
+                        const elem = {
+                            action: Action.eliminate,
+                            alternative: minAlternative,
+                            minScore: Number(iterationMinScore.toFixed(4)),
+                        };
+                        log.push(elem);
+                        doneAlternatives[minAlternative._id] = {};
+                    }
+                    break;
+                }
+            }
+            else {
+                const minAlternative = minAlternatives[0];
+                if (minAlternative) {
+                    const elemLowest = {
+                        action: Action.eliminate,
+                        alternative: minAlternative,
+                        minScore: Number(minScore.toFixed(4)),
+                    };
+                    log.push(elemLowest);
+                    doneAlternatives[minAlternative._id] = {};
+                }
+            }
+            nextRoundVotes = votes;
+        }
+        votes = nextRoundVotes.map((vote) => {
+            vote['priorities'] = vote.priorities.filter((alternative) => !doneAlternatives[alternative._id]);
+            return vote;
         });
-
-        // As long as the reverseIteration is larger than 1 we can look further back
-        while (reverseIteration >= 1) {
-          // Find the log object for the last iteration
-          const logObject = log.find(
-            (entry) => entry.iteration === reverseIteration
-          );
-
-          // Find the lowest score (with regard to the alternatives in the actual iteration)
-          const iterationMinScore = Math.min(
-            ...minAlternatives.map((a) => logObject.counts[a.description] || 0)
-          );
-
-          // Find the candidates (in regard to the actual iteration) that has the lowest score
-          const iterationMinAlternatives = minAlternatives.filter(
-            (alternative) =>
-              (logObject.counts[alternative.description] || 0) <=
-              iterationMinScore + EPSILON
-          );
-
-          // If we are at iteration lvl 1 and there is still a tie we cannot do anything
-          if (reverseIteration === 1 && iterationMinAlternatives.length > 1) {
-            log.push({
-              action: 'TIE',
-              description:
-                'The backward checking went to iteration 1 without breaking the tie',
-            });
-            // Eliminate all candidates that are in the last iterationMinAlternatives
-            log.push({
-              action: 'MULTI_TIE_ELIMINATIONS',
-              alternatives: iterationMinAlternatives,
-              minScore: Number(minScore.toFixed(4)),
-            });
-            iterationMinAlternatives.forEach(
-              (alternative) => (doneAlternatives[alternative._id] = {})
-            );
-            break;
-          }
-
-          reverseIteration--;
-          // If there is a tie at this iteration as well we must continue the loop
-          if (iterationMinAlternatives.length > 1) continue;
-
-          // There is only one candidate with the lowest score
-          const minAlternative = iterationMinAlternatives[0];
-          if (minAlternative) {
-            log.push({
-              action: 'ELIMINATE',
-              alternative: minAlternative,
-              minScore: Number(iterationMinScore.toFixed(4)),
-            });
-            doneAlternatives[minAlternative._id] = {};
-          }
-          break;
-        }
-      } else {
-        // There is only one candidate with the lowest score
-        const minAlternative = minAlternatives[0];
-        if (minAlternative) {
-          log.push({
-            action: 'ELIMINATE',
-            alternative: minAlternative,
-            minScore: Number(minScore.toFixed(4)),
-          });
-          doneAlternatives[minAlternative._id] = {};
-        }
-      }
-      nextRoundVotes = votes;
+        alternatives = alternatives.filter((alternative) => !doneAlternatives[alternative._id]);
     }
-
-    // We filter out the alternatives of the doneAlternatives from the list of nextRoundVotes
-    votes = nextRoundVotes.map((vote) => {
-      vote['priorities'] = vote.priorities.filter(
-        (alternative) => !doneAlternatives[alternative._id]
-      );
-      return vote;
-    });
-    // Remove the alternatives that are done
-    alternatives = alternatives.filter(
-      (alternative) => !doneAlternatives[alternative._id]
-    );
-  }
-  return {
-    result: { status: 'UNRESOLVED', winners },
-    log,
-    thr,
-    seats,
-    voteCount: inputVotes.length,
-    useStrict,
-  };
+    return {
+        result: { status: Status.unresolved, winners },
+        log,
+        thr,
+        seats,
+        voteCount: inputVotes.length,
+        useStrict,
+    };
 };
-
-// Round floats to fixed in output
 const handleFloatsInOutput = (obj) => {
-  let newObj = {};
-  Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
-  return newObj;
+    const newObj = {};
+    Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
+    return newObj;
 };
+//# sourceMappingURL=stv.js.map

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -3,6 +3,8 @@
  *   result: STVResult;
  *   log: STVEvent[];
  *   thr: number;
+ *   seats: number;
+ *   voteCount: number;
  * };
  *
  * type Alternative = {
@@ -196,6 +198,8 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
           result: { status: 'RESOLVED', winners },
           log,
           thr,
+          seats,
+          voteCount: votes.length,
         };
       }
 
@@ -282,7 +286,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
             // Eliminate all candidates that are in the last iterationMinAlternatives
             log.push({
               action: 'MULTI_TIE_ELIMINATIONS',
-              alternatives: alternatives,
+              alternatives: iterationMinAlternatives,
               minScore: Number(minScore.toFixed(4)),
             });
             iterationMinAlternatives.forEach(
@@ -338,6 +342,8 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
     result: { status: 'UNRESOLVED', winners },
     log,
     thr,
+    seats,
+    voteCount: votes.length,
   };
 };
 

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -136,7 +136,7 @@ exports.calculateWinnerUsingSTV = (
       const vote = JSON.parse(JSON.stringify(votes[i]));
 
       // @const { Alternative } currentAlternative - We always count the first value (priorities[0])
-      // because there is a mutation step that removed values that are "done". These are values
+      // because there is a mutation step that removes values that are "done". These are values
       // connected to candidates that have either won or been eliminated from the election.
       const currentAlternative = JSON.parse(JSON.stringify(vote.priorities[0]));
 
@@ -164,7 +164,7 @@ exports.calculateWinnerUsingSTV = (
     for (let i in alternatives) {
       // @const { Alternative } alternative - Get an alternative
       const alternative = JSON.parse(JSON.stringify(alternatives[i]));
-      // @const { float } voteCount - Find the number number of votes for this alternative
+      // @const { float } voteCount - Find the number of votes for this alternative
       const voteCount = counts[alternative.description] || 0;
 
       // If an alternative has enough votes, add them as round winner
@@ -271,7 +271,7 @@ exports.calculateWinnerUsingSTV = (
           )} at iteration ${reverseIteration}`,
         });
 
-        // As long as the reveseindex is still larger then 1 we can look further back
+        // As long as the reverseIteration is larger than 1 we can look further back
         while (reverseIteration >= 1) {
           // Find the log object for the last iteration
           const logObject = log.find(

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -251,10 +251,10 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
           )} at iteration ${reverseIteration}`,
         });
 
-        // If the minScore is 0 or 1 we eliminate a random candidate as Scottish STV specifies
-        // This is only done in the low cases of 0 or 1, and we would rather return an unresolved
+        // If the minScore is 0 we eliminate a random candidate as Scottish STV specifies
+        // This is only done in the low case of 0, and we would rather return an unresolved
         // election if the TIE cannot be solved by backtracking.
-        if (minScore === 0 || minScore === 1) {
+        if (minScore === 0) {
           const randomAlternative =
             minAlternatives[Math.floor(Math.random() * minAlternatives.length)];
           log.push({

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -38,8 +38,8 @@
  *       minScore: number;
  *     }
  *   | {
- *       action: 'TIEELIMINATE';
- *       alternative: Alternative;
+ *       action: 'MULTI_TIE_ELIMINATIONS';
+ *       alternatives: Alternative[];
  *       minScore: number;
  *     }
  *   | {
@@ -255,8 +255,6 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
 
         // As long as the reveseindex is still larger then 1 we can look further back
         while (reverseIteration >= 1) {
-          reverseIteration--;
-
           // Find the log object for the last iteration
           const logObject = log.find(
             (entry) => entry.iteration === reverseIteration
@@ -282,18 +280,18 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
                 'The backward checking went to iteration 1 without breaking the tie',
             });
             // Eliminate all candidates that are in the last iterationMinAlternatives
-            iterationMinAlternatives.forEach((alternative) => {
-              // Log the tie elimination
-              log.push({
-                action: 'TIEELIMINATE',
-                alternative: alternative,
-                minScore: Number(minScore.toFixed(4)),
-              });
-              doneAlternatives[alternative._id] = {};
+            log.push({
+              action: 'MULTI_TIE_ELIMINATIONS',
+              alternatives: alternatives,
+              minScore: Number(minScore.toFixed(4)),
             });
+            iterationMinAlternatives.forEach(
+              (alternative) => (doneAlternatives[alternative._id] = {})
+            );
             break;
           }
 
+          reverseIteration--;
           // If there is a tie at this iteration as well we must continue the loop
           if (iterationMinAlternatives.length > 1) continue;
 
@@ -321,8 +319,6 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
           doneAlternatives[minAlternative._id] = {};
         }
       }
-
-      // ==================================================================================
       nextRoundVotes = votes;
     }
 

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -1,0 +1,278 @@
+/** Types used in this file
+ * type STV = {
+ *   result: STVResult;
+ *   log: STVEvent[];
+ *   thr: number;
+ * };
+ *
+ * type Alternative = {
+ *   _id: string;
+ *   description: string;
+ *   election: string;
+ * };
+ *
+ * type Vote = {
+ *   _id: string;
+ *   priorities: Alternative[];
+ *   hash: string;
+ *   weight: number;
+ * };
+ *
+ * type STVEvent =
+ *   | {
+ *       action: 'ITERATION';
+ *       iteration: number;
+ *       winners: Alternative[];
+ *       alternatives: Alternative[];
+ *       votes: Vote[];
+ *       counts: { [key: string]: number };
+ *     }
+ *   | {
+ *       action: 'WIN';
+ *       alternative: Alternative;
+ *       voteCount: number;
+ *     }
+ *   | {
+ *       action: 'ELIMINATE';
+ *       alternatives: Alternative[];
+ *       minScore: number;
+ *     };
+ * type STVResult =
+ *   | {
+ *       status: 'RESOLVED';
+ *       winners: Alternative[];
+ *     }
+ *   | {
+ *       status: 'UNRESOLVED';
+ *       winners: Alternative[];
+ *     };
+ */
+
+/**
+ * The Droop qouta https://en.wikipedia.org/wiki/Droop_quota
+ * @param { Vote[] } votes - All votes for the election
+ * @param { int } seats - The number of seats in this election
+ *
+ * @return { int } The amount votes needed to be elected
+ */
+const winningThreshold = (votes, seats) => {
+  return Math.floor(votes.length / (seats + 1) + 1);
+};
+
+// Epsilon value used in comparisons of floating point errors. See dataset5.js.
+const EPSILON = 0.000001;
+
+/**
+ * Will calculate the election result using Single Transferable Vote
+ * @param { Vote[] } votes - All votes for the election
+ * @param { Alternative[] } alternatives - All possible alternatives for the election
+ * @param { int } seats - The number of seats in this election
+ *
+ * @return { SVT } The full election, including result, log and threshold value
+ */
+exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
+  // @let { SVTEvent[] } log - Will hold the log for the entire election
+  let log = [];
+
+  // Stringify and clean the votes
+  votes = votes.map((vote) => ({
+    _id: String(vote._id),
+    priorities: vote.priorities.map((alternative) => ({
+      _id: String(alternative._id),
+      election: String(alternative.election),
+      description: alternative.description,
+    })),
+    hash: vote.hash,
+    weight: 1,
+  }));
+
+  // Stingify and clean the alternatives
+  alternatives = alternatives.map((alternative) => ({
+    _id: String(alternative._id),
+    description: alternative.description,
+    election: String(alternative.election),
+  }));
+
+  // @const { int } thr - The threshold value needed to win
+  const thr = winningThreshold(votes, seats);
+
+  // @let { Alternative[] } winners - Winners for the election
+  let winners = [];
+
+  // @let { int } iteration - The election is a while loop, and with each iteration
+  // we count the number of first place votes each candidate has.
+  let iteration = 0;
+  while (votes.length > 0) {
+    iteration += 1;
+
+    // Remove empty votes, this happens after the threshold is calculated
+    // in order to preserve "blank votes"
+    votes = votes.filter((vote) => vote.priorities.length > 0);
+
+    // @let { [key: string]: float } counts - Dict with the counts for each candidate
+    let counts = {};
+
+    for (let i in votes) {
+      // @const { Vote } vote - The vote for this loop
+      const vote = votes[i];
+
+      // @const { Alternative } currentAlternative - We always count the first value (priorities[0])
+      // because there is a mutation step that removed values that are "done". These are values
+      // connected to candidates that have either won or been eliminated from the election.
+      const currentAlternative = vote.priorities[0];
+
+      // Use the alternatives description as key in the counts, and add one for each count
+      counts[currentAlternative.description] =
+        vote.weight + (counts[currentAlternative.description] || 0);
+    }
+
+    // Push Iteration to log
+    log.push({
+      action: 'ITERATION',
+      iteration,
+      winners: winners.slice(),
+      // TODO find a better way to return this?
+      //alternatives: alternatives.slice(),
+      //votes: votes.slice(),
+      counts,
+    });
+
+    // @let { [key: string]: {} } roundWinner - Dict of winners
+    let roundWinners = {};
+    // @let { [key: string]: float } excessFractions - Dict of excess fractions per key
+    let excessFractions = {};
+    // @let { [key: string]: {} } doneVotes - Dict of done votes
+    let doneVotes = {};
+
+    // Loop over the different alternatives
+    for (let i in alternatives) {
+      // @const { Alternative } alternative - Get an alternative
+      const alternative = alternatives[i];
+      // @const { float } voteCount - Find the number number of votes for this alternative
+      const voteCount = counts[alternative.description] || 0;
+
+      // If an alternative has enough votes, add them as round winner
+      // Due to JavaScript float precision errors this voteCount is checked with a range
+      if (voteCount >= thr - EPSILON) {
+        // Calculate the excess fraction of votes, above the threshold
+        excessFractions[alternative._id] = (voteCount - thr) / voteCount;
+
+        // Add the alternatives ID to the dict of winners this round
+        roundWinners[alternative._id] = {};
+
+        // Push the whole alternative to the list of new winners
+        winners.push(alternative);
+
+        // Add the WIN action to the iteration log
+        log.push({
+          action: 'WIN',
+          alternative,
+          voteCount,
+        });
+
+        // Find the done Votes
+        for (let i in votes) {
+          // @const { Vote } vote - The vote for this loop
+          const vote = votes[i];
+
+          // Votes that have the winning alternative as their first pick
+          if (vote.priorities[0]._id === alternative._id) doneVotes[i] = {};
+        }
+      }
+    }
+
+    // @let { [key: string]: {} } doneAlternatives - Have won or been eliminated
+    let doneAlternatives = {};
+
+    // @let { Vote[] } nextRoundVotes - The votes that will go on to the next round
+    let nextRoundVotes = [];
+
+    // If there are new winners this round
+    if (Object.keys(roundWinners).length > 0) {
+      // Check STV can terminate and return the RESOLVED winners
+      if (winners.length === seats) {
+        return {
+          result: { status: 'RESOLVED', winners },
+          log,
+          thr,
+        };
+      }
+
+      // Set the done alternatives as the roundwinners
+      doneAlternatives = roundWinners;
+
+      // The next rounds votes are votes that are not done.
+      nextRoundVotes = votes.filter((_, i) => !doneVotes[i]);
+
+      // Go through all done votes
+      for (let i in doneVotes) {
+        // @const { Vote } vote - The vote for this loop
+        const vote = votes[i];
+
+        // @const { Alternative } alternative - Take the first choice of the done vote
+        const alternative = vote.priorities[0];
+
+        // @const { float } fraction - Find the excess fraction for this alternative
+        const fraction = excessFractions[alternative._id] || 0;
+
+        // If the fraction is 0 (meaning no votes should be transferred) or if the vote
+        // has no more priorities (meaning it's exhausted) we can continue without transfer
+        if (fraction === 0 || vote.priorities.length === 1) continue;
+
+        // Fractional transfer. We mutate the weight for these votes by a fraction
+        vote['weight'] = vote.weight * fraction;
+        // Push the mutated votes to the list of votes to be processed in the next iteration
+        nextRoundVotes.push(vote);
+      }
+    } else {
+      // If there are no new winners we must eliminate someone in order to progress the election
+
+      // ==================================================================================
+      // TODO! Temp implementation to eliminate the users with the lowest score
+      const minScore = Math.min(
+        ...alternatives.map(
+          (alternative) => counts[alternative.description] || 0
+        )
+      );
+      const minAlternatives = alternatives.filter(
+        (alternative) =>
+          (counts[alternative.description] || 0) <= minScore + EPSILON
+      );
+
+      log.push({
+        action: 'ELIMINATE',
+        alternatives: minAlternatives,
+        minScore,
+      });
+      minAlternatives.forEach(
+        (alternatives) => (doneAlternatives[alternatives._id] = {})
+      );
+      // ==================================================================================
+      nextRoundVotes = votes;
+    }
+
+    // We filter out the alternatives of the doneAlternatives from the list of nextRoundVotes
+    votes = nextRoundVotes.map((vote) => {
+      vote['priorities'] = vote.priorities.filter(
+        (alternative) => !doneAlternatives[alternative._id]
+      );
+      return vote;
+    });
+    // Remove the alternatives that are done
+    alternatives = alternatives.filter(
+      (alternative) => !doneAlternatives[alternative._id]
+    );
+  }
+  return {
+    result: { status: 'UNRESOLVED', winners },
+    log,
+    thr,
+  };
+};
+
+// Round floats to fixed in output
+// const handleFloatsInOutput = (obj) => {
+//   let newObj = {};
+//   Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
+//   return newObj;
+// };

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -77,21 +77,13 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
   // Stringify and clean the votes
   votes = votes.map((vote) => ({
     _id: String(vote._id),
-    priorities: vote.priorities.map((alternative) => ({
-      _id: String(alternative._id),
-      election: String(alternative.election),
-      description: alternative.description,
-    })),
+    priorities: JSON.parse(JSON.stringify(vote.priorities)),
     hash: vote.hash,
     weight: 1,
   }));
 
   // Stingify and clean the alternatives
-  alternatives = alternatives.map((alternative) => ({
-    _id: String(alternative._id),
-    description: alternative.description,
-    election: String(alternative.election),
-  }));
+  alternatives = JSON.parse(JSON.stringify(alternatives));
 
   // @const { int } thr - The threshold value needed to win
   const thr = winningThreshold(votes, seats);
@@ -131,10 +123,9 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
       action: 'ITERATION',
       iteration,
       winners: winners.slice(),
-      // TODO find a better way to return this?
-      //alternatives: alternatives.slice(),
-      //votes: votes.slice(),
-      counts,
+      alternatives: alternatives.slice(),
+      votes: votes.slice(),
+      counts: handleFloatsInOutput(counts),
     });
 
     // @let { [key: string]: {} } roundWinner - Dict of winners
@@ -167,7 +158,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
         log.push({
           action: 'WIN',
           alternative,
-          voteCount,
+          voteCount: Number(voteCount.toFixed(4)),
         });
 
         // Find the done Votes
@@ -242,7 +233,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
       log.push({
         action: 'ELIMINATE',
         alternatives: minAlternatives,
-        minScore,
+        minScore: Number(minScore.toFixed(4)),
       });
       minAlternatives.forEach(
         (alternatives) => (doneAlternatives[alternatives._id] = {})
@@ -271,8 +262,8 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
 };
 
 // Round floats to fixed in output
-// const handleFloatsInOutput = (obj) => {
-//   let newObj = {};
-//   Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
-//   return newObj;
-// };
+const handleFloatsInOutput = (obj) => {
+  let newObj = {};
+  Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
+  return newObj;
+};

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -81,12 +81,12 @@ const EPSILON = 0.000001;
  *
  * @return { STV } The full election, including result, log and threshold value
  */
-exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
+exports.calculateWinnerUsingSTV = (inputVotes, inputAlternatives, seats) => {
   // @let { STVEvent[] } log - Will hold the log for the entire election
   let log = [];
 
   // Stringify and clean the votes
-  votes = votes.map((vote) => ({
+  let votes = inputVotes.map((vote) => ({
     _id: String(vote._id),
     priorities: JSON.parse(JSON.stringify(vote.priorities)),
     hash: vote.hash,
@@ -94,7 +94,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
   }));
 
   // Stringify and clean the alternatives
-  alternatives = JSON.parse(JSON.stringify(alternatives));
+  let alternatives = JSON.parse(JSON.stringify(inputAlternatives));
 
   // @const { int } thr - The threshold value needed to win
   const thr = winningThreshold(votes, seats);
@@ -134,9 +134,6 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
       action: 'ITERATION',
       iteration,
       winners: winners.slice(),
-      // TODO Find a better way to this, the test assertions are slow AF with this
-      //alternatives: alternatives.slice(),
-      //votes: votes.slice(),
       counts: handleFloatsInOutput(counts),
     });
 
@@ -199,7 +196,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
           log,
           thr,
           seats,
-          voteCount: votes.length,
+          voteCount: inputVotes.length,
         };
       }
 
@@ -343,7 +340,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
     log,
     thr,
     seats,
-    voteCount: votes.length,
+    voteCount: inputVotes.length,
   };
 };
 

--- a/app/stv/stv.js
+++ b/app/stv/stv.js
@@ -114,12 +114,12 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
 
     for (let i in votes) {
       // @const { Vote } vote - The vote for this loop
-      const vote = Object.create(votes[i]);
+      const vote = JSON.parse(JSON.stringify(votes[i]));
 
       // @const { Alternative } currentAlternative - We always count the first value (priorities[0])
       // because there is a mutation step that removed values that are "done". These are values
       // connected to candidates that have either won or been eliminated from the election.
-      const currentAlternative = Object.create(vote.priorities[0]);
+      const currentAlternative = JSON.parse(JSON.stringify(vote.priorities[0]));
 
       // Use the alternatives description as key in the counts, and add one for each count
       counts[currentAlternative.description] =
@@ -147,7 +147,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
     // Loop over the different alternatives
     for (let i in alternatives) {
       // @const { Alternative } alternative - Get an alternative
-      const alternative = Object.create(alternatives[i]);
+      const alternative = JSON.parse(JSON.stringify(alternatives[i]));
       // @const { float } voteCount - Find the number number of votes for this alternative
       const voteCount = counts[alternative.description] || 0;
 
@@ -173,7 +173,7 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
         // Find the done Votes
         for (let i in votes) {
           // @const { Vote } vote - The vote for this loop
-          const vote = Object.create(votes[i]);
+          const vote = JSON.parse(JSON.stringify(votes[i]));
 
           // Votes that have the winning alternative as their first pick
           if (vote.priorities[0]._id === alternative._id) doneVotes[i] = {};
@@ -207,10 +207,10 @@ exports.calculateWinnerUsingSTV = (votes, alternatives, seats) => {
       // Go through all done votes
       for (let i in doneVotes) {
         // @const { Vote } vote - The vote for this loop
-        const vote = Object.create(votes[i]);
+        const vote = JSON.parse(JSON.stringify(votes[i]));
 
         // @const { Alternative } alternative - Take the first choice of the done vote
-        const alternative = Object.create(vote.priorities[0]);
+        const alternative = JSON.parse(JSON.stringify(vote.priorities[0]));
 
         // @const { float } fraction - Find the excess fraction for this alternative
         const fraction = excessFractions[alternative._id] || 0;

--- a/app/stv/stv.ts
+++ b/app/stv/stv.ts
@@ -1,0 +1,415 @@
+import cloneDeep = require('lodash/cloneDeep');
+
+// This is a TypeScript file in a JavaScript project so it must be complied
+// If you make changes to this file it must be recomplied using `tsc` in
+// order for the changes to be reflected in the rest of the program.
+//
+// app/models/election .elect() is the only file that uses this function
+// and importes it from stv.js, which is the compiled result of this file.
+
+type STV = {
+  result: STVResult;
+  log: STVEvent[];
+  thr: number;
+  seats: number;
+  voteCount: number;
+  useStrict: boolean;
+};
+
+type Alternative = {
+  _id: string;
+  description: string;
+  election: string;
+};
+
+type Vote = {
+  _id: string;
+  priorities: Alternative[];
+  hash: string;
+  weight: number;
+};
+
+enum Action {
+  iteration = 'ITERATION',
+  win = 'WIN',
+  eliminate = 'ELIMINATE',
+  multi_tie_eliminations = 'MULTI_TIE_ELIMINATIONS',
+  tie = 'TIE',
+}
+
+type STVEvent = {
+  action: Action;
+  iteration?: number;
+  winners?: Alternative[];
+  counts?: { [key: string]: number };
+  alternative?: Alternative;
+  alternatives?: Alternative[];
+  voteCount?: number;
+  minScore?: number;
+  description?: string;
+};
+
+interface STVEventIteration extends STVEvent {
+  action: Action.iteration;
+  iteration: number;
+  winners: Alternative[];
+  counts: { [key: string]: number };
+}
+
+interface STVEventWin extends STVEvent {
+  action: Action.win;
+  alternative: Alternative;
+  voteCount: number;
+}
+interface STVEventEliminate extends STVEvent {
+  action: Action.eliminate;
+  alternative: Alternative;
+  minScore: number;
+}
+interface STVEventTie extends STVEvent {
+  action: Action.tie;
+  description: string;
+}
+interface STVEventMulti extends STVEvent {
+  action: Action.multi_tie_eliminations;
+  alternatives: Alternative[];
+  minScore: number;
+}
+
+enum Status {
+  resolved = 'RESOLVED',
+  unresolved = 'UNRESOLVED',
+}
+
+type STVResult =
+  | {
+      status: Status;
+      winners: Alternative[];
+    }
+  | {
+      status: Status;
+      winners: Alternative[];
+    };
+
+/**
+ * The Droop qouta https://en.wikipedia.org/wiki/Droop_quota
+ * @param votes - All votes for the election
+ * @param seats - The number of seats in this election
+ * @param useStrict - Sets the threshold to 67% no matter what
+ *
+ * @return The amount votes needed to be elected
+ */
+const winningThreshold = (
+  votes: Vote[],
+  seats: number,
+  useStrict: boolean
+): number => {
+  if (useStrict) {
+    return Math.floor((2 * votes.length) / 3) + 1;
+  }
+  return Math.floor(votes.length / (seats + 1) + 1);
+};
+
+// Epsilon value used in comparisons of floating point errors. See dataset5.js.
+const EPSILON = 0.000001;
+
+/**
+ * Will calculate the election result using Single Transferable Vote
+ * @param votes - All votes for the election
+ * @param alternatives - All possible alternatives for the election
+ * @param seats - The number of seats in this election. Default 1
+ * @param useStrict - This election will require a qualified majority. Default false
+ *
+ * @return The full election, including result, log and threshold value
+ */
+exports.calculateWinnerUsingSTV = (
+  inputVotes: any,
+  inputAlternatives: any,
+  seats = 1,
+  useStrict = false
+): STV => {
+  // Hold the log for the entire election
+  const log: STVEvent[] = [];
+
+  // Stringify and clean the votes
+  let votes: Vote[] = inputVotes.map((vote: any) => ({
+    _id: String(vote._id),
+    priorities: vote.priorities.map((vote: any) => ({
+      _id: String(vote._id),
+      description: vote.description,
+      election: String(vote._id),
+    })),
+    hash: vote.hash,
+    weight: 1,
+  }));
+
+  // Stringify and clean the alternatives
+  let alternatives: Alternative[] = inputAlternatives.map(
+    (alternative: any) => ({
+      _id: String(alternative._id),
+      description: alternative.description,
+      election: String(alternative._id),
+    })
+  );
+
+  // The threshold value needed to win
+  const thr: number = winningThreshold(votes, seats, useStrict);
+
+  // Winners for the election
+  const winners: Alternative[] = [];
+
+  // With each iteration we count the number of first place votes each candidate has.
+  let iteration = 0;
+  while (votes.length > 0 && iteration < 100) {
+    iteration += 1;
+
+    // Remove empty votes after threshold in order to preserve "blank votes"
+    votes = votes.filter((vote: Vote) => vote.priorities.length > 0);
+
+    // Dict with the counts for each candidate
+    const counts: { [key: string]: number } = {};
+
+    for (const i in votes) {
+      // The vote for this loop
+      const vote = cloneDeep(votes[i]);
+
+      // We always count the first value (priorities[0]) because there is a mutation step
+      // that removes values that are "done". These are values connected to candidates
+      // that have either won or been eliminated from the election.
+      const currentAlternative = cloneDeep(vote.priorities[0]);
+
+      // Use the alternatives description as key in the counts, and add one for each count
+      counts[currentAlternative.description] =
+        vote.weight + (counts[currentAlternative.description] || 0);
+    }
+
+    // Push Iteration to log
+    const iterationLog: STVEventIteration = {
+      action: Action.iteration,
+      iteration,
+      winners: winners.slice(),
+      counts: handleFloatsInOutput(counts),
+    };
+    log.push(iterationLog);
+
+    // Dict of winners
+    const roundWinners: { [key: string]: {} } = {};
+    // Dict of excess fractions per key
+    const excessFractions: { [key: string]: number } = {};
+    // Dict of done votes
+    const doneVotes: { [key: number]: {} } = {};
+
+    // Loop over the different alternatives
+    for (const i in alternatives) {
+      // Get an alternative
+      const alternative: Alternative = cloneDeep(alternatives[i]);
+      // Find the number of votes for this alternative
+      const voteCount: number = counts[alternative.description] || 0;
+
+      // If an alternative has enough votes, add them as round winner
+      // Due to JavaScript float precision errors this voteCount is checked with a range
+      if (voteCount >= thr - EPSILON) {
+        // Calculate the excess fraction of votes, above the threshold
+        excessFractions[alternative._id] = (voteCount - thr) / voteCount;
+
+        // Add the alternatives ID to the dict of winners this round
+        roundWinners[alternative._id] = {};
+
+        // Push the whole alternative to the list of new winners
+        winners.push(alternative);
+
+        // Add the WIN action to the iteration log
+        const winLog: STVEventWin = {
+          action: Action.win,
+          alternative,
+          voteCount: Number(voteCount.toFixed(4)),
+        };
+        log.push(winLog);
+
+        // Find the done Votes
+        for (const i in votes) {
+          // The vote for this loop
+          const vote: Vote = cloneDeep(votes[i]);
+
+          // Votes that have the winning alternative as their first pick
+          if (vote.priorities[0]._id === alternative._id) doneVotes[i] = {};
+        }
+      }
+    }
+
+    // Have won or been eliminated
+    let doneAlternatives: { [key: string]: {} } = {};
+
+    // The votes that will go on to the next round
+    let nextRoundVotes: Vote[] = [];
+
+    // If there are new winners this round
+    if (Object.keys(roundWinners).length > 0) {
+      // Check STV can terminate and return the RESOLVED winners
+      if (winners.length === seats) {
+        return {
+          result: { status: Status.resolved, winners },
+          log,
+          thr,
+          seats,
+          voteCount: inputVotes.length,
+          useStrict,
+        };
+      }
+
+      // Set the done alternatives as the roundwinners
+      doneAlternatives = roundWinners;
+
+      // The next rounds votes are votes that are not done.
+      nextRoundVotes = votes.filter((_, i) => !doneVotes[i]);
+
+      // Go through all done votes
+      for (const i in doneVotes) {
+        // The vote for this loop
+        const vote: Vote = cloneDeep(votes[i]);
+
+        // Take the first choice of the done vote
+        const alternative: Alternative = cloneDeep(vote.priorities[0]);
+
+        // Find the excess fraction for this alternative
+        const fraction: number = excessFractions[alternative._id] || 0;
+
+        // If the fraction is 0 (meaning no votes should be transferred) or if the vote
+        // has no more priorities (meaning it's exhausted) we can continue without transfer
+        if (fraction === 0 || vote.priorities.length === 1) continue;
+
+        // Fractional transfer. We mutate the weight for these votes by a fraction
+        vote['weight'] = vote.weight * fraction;
+        // Push the mutated votes to the list of votes to be processed in the next iteration
+        nextRoundVotes.push(vote);
+      }
+    } else {
+      // Find the lowest score
+      const minScore: number = Math.min(
+        ...alternatives.map(
+          (alternative) => counts[alternative.description] || 0
+        )
+      );
+
+      // Find the candidates with the lowest score
+      const minAlternatives: Alternative[] = alternatives.filter(
+        (alternative) =>
+          (counts[alternative.description] || 0) <= minScore + EPSILON
+      );
+
+      // There is a tie for eliminating candidates. Per Scottish STV we must look at the previous rounds
+      if (minAlternatives.length > 1) {
+        let reverseIteration = iteration;
+
+        // Log the Tie
+        const tieObject: STVEventTie = {
+          action: Action.tie,
+          description: `There are ${
+            minAlternatives.length
+          } candidates with a score of ${Number(
+            minScore.toFixed(4)
+          )} at iteration ${reverseIteration}`,
+        };
+        log.push(tieObject);
+
+        // As long as the reverseIteration is larger than 1 we can look further back
+        while (reverseIteration >= 1) {
+          // Find the log object for the last iteration
+          const logObject: STVEvent = log.find(
+            (entry: STVEventIteration) => entry.iteration === reverseIteration
+          );
+
+          // Find the lowest score (with regard to the alternatives in the actual iteration)
+          const iterationMinScore = Math.min(
+            ...minAlternatives.map((a) => logObject.counts[a.description] || 0)
+          );
+
+          // Find the candidates (in regard to the actual iteration) that has the lowest score
+          const iterationMinAlternatives = minAlternatives.filter(
+            (alternative: Alternative) =>
+              (logObject.counts[alternative.description] || 0) <=
+              iterationMinScore + EPSILON
+          );
+
+          // If we are at iteration lvl 1 and there is still a tie we cannot do anything
+          if (reverseIteration === 1 && iterationMinAlternatives.length > 1) {
+            const backTrackFailed: STVEventTie = {
+              action: Action.tie,
+              description:
+                'The backward checking went to iteration 1 without breaking the tie',
+            };
+            log.push(backTrackFailed);
+
+            // Eliminate all candidates that are in the last iterationMinAlternatives
+            const multiTieElem: STVEventMulti = {
+              action: Action.multi_tie_eliminations,
+              alternatives: iterationMinAlternatives,
+              minScore: Number(minScore.toFixed(4)),
+            };
+            log.push(multiTieElem);
+            iterationMinAlternatives.forEach(
+              (alternative) => (doneAlternatives[alternative._id] = {})
+            );
+            break;
+          }
+
+          reverseIteration--;
+          // If there is a tie at this iteration as well we must continue the loop
+          if (iterationMinAlternatives.length > 1) continue;
+          // There is only one candidate with the lowest score
+          const minAlternative = iterationMinAlternatives[0];
+          if (minAlternative) {
+            const elem: STVEventEliminate = {
+              action: Action.eliminate,
+              alternative: minAlternative,
+              minScore: Number(iterationMinScore.toFixed(4)),
+            };
+            log.push(elem);
+            doneAlternatives[minAlternative._id] = {};
+          }
+          break;
+        }
+      } else {
+        // There is only one candidate with the lowest score
+        const minAlternative = minAlternatives[0];
+        if (minAlternative) {
+          const elemLowest: STVEventEliminate = {
+            action: Action.eliminate,
+            alternative: minAlternative,
+            minScore: Number(minScore.toFixed(4)),
+          };
+          log.push(elemLowest);
+          doneAlternatives[minAlternative._id] = {};
+        }
+      }
+      nextRoundVotes = votes;
+    }
+
+    // We filter out the alternatives of the doneAlternatives from the list of nextRoundVotes
+    votes = nextRoundVotes.map((vote) => {
+      vote['priorities'] = vote.priorities.filter(
+        (alternative) => !doneAlternatives[alternative._id]
+      );
+      return vote;
+    });
+    // Remove the alternatives that are done
+    alternatives = alternatives.filter(
+      (alternative) => !doneAlternatives[alternative._id]
+    );
+  }
+  return {
+    result: { status: Status.unresolved, winners },
+    log,
+    thr,
+    seats,
+    voteCount: inputVotes.length,
+    useStrict,
+  };
+};
+
+// Round floats to fixed in output
+const handleFloatsInOutput = (obj: Object) => {
+  const newObj = {};
+  Object.entries(obj).forEach(([k, v]) => (newObj[k] = Number(v.toFixed(4))));
+  return newObj;
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "db:seed": "node --no-deprecation test/scripts/db_seed.js",
     "lint": "yarn lint:eslint && yarn lint:prettier && yarn lint:yaml",
     "lint:eslint": "eslint . --ignore-path .gitignore",
-    "lint:prettier": "prettier '**/*.{js,pug}' --list-different --ignore-path .gitignore",
+    "lint:prettier": "prettier '**/*.{js,ts,pug}' --list-different",
     "lint:yaml": "yarn yamllint .drone.yml docker-compose.yml usage.yml deployment/docker-compose.yml",
     "prettier": "prettier '**/*.{js,pug}' --write",
     "mocha": "NODE_ENV=test MONGO_URL=${MONGO_URL:-'mongodb://localhost:27017/vote-test'} nyc mocha test/**/*.test.js --exit --timeout 3000",
@@ -30,6 +30,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/lodash": "4.14.167",
     "angular": "1.8.0",
     "angular-animate": "1.7.9",
     "angular-local-storage": "0.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "target": "es2015",
+    "outDir": "app/stv",
+    "module": "commonjs",
+    "removeComments": true
+  },
+  "include": [
+    "app/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@4.14.167":
+  version "4.14.167"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
+  integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
## Implementation for the STV algorithm used by the `elect()` method.

Helps to solve #351, #361 and #378 

This is the main logic to elect candidates based only on the `(votes, alternatives, seats) => ()` of the election.
Credits go to @JonasBak for writing 95% of the logic. I've just adjusted it to fit into **Vote**.

As one might see, there are a lot of TypeScript comments in the file, as the original implementation was done in TypeScript while creating it. We still have many of the types here to give an overview of what the different `Object {}` are.

#### Todos
- [x] Handle elimination where the two bottom candidates have the same number of votes
- [x] Handle floating-point errors in output (already handled in the calculations and logic)
- [x] Maybe remove some comments after people agree on the implementation
- [x] Don't mutate the vote at line 222, as this will update the log as well
- [x] Implement strict STV election as per https://github.com/webkom/vote/issues/378