### PR TITLE
Add web nfc support

### DIFF
--- a/app/views/partials/moderator/serial_error.pug
+++ b/app/views/partials/moderator/serial_error.pug
@@ -20,3 +20,10 @@
       target='_blank'
     ) README.md
   hr
+  br
+  .text-center
+    h4 Dummy card reader
+    h5
+      Open devtools and click
+      = " "
+      a(href='/moderator/create_user?dummyReader') here

--- a/client/services/cardKeyService.js
+++ b/client/services/cardKeyService.js
@@ -143,7 +143,7 @@ Usage: scanCard(123) // where 123 is the cardId `);
             // Keep reading bytes until the "end" byte is sent
             // The "end" byte is 0xbb
             while (!finished) {
-              const { value } = await $rootScope.serialReader.read();
+              const { value } = await $rootScope.serialDevice.reader.read();
               for (let i = 0; i < value.length; i++) {
                 // First byte in a message should be 170, otherwise ignore and keep on going
                 if (message.length === 0 && value[i] !== 170) {

--- a/client/services/cardKeyService.js
+++ b/client/services/cardKeyService.js
@@ -74,8 +74,23 @@ module.exports = [
         angular.element($window).bind('message', function (e) {
           cb(e.data);
         });
+        if ($window.location.href.includes('dummyReader')) {
+          $rootScope.dummyReader = true;
+          $window.scanCard = (cardKey) =>
+            $window.window.postMessage(cardKey, '*');
+
+          $window.console.error(`VOTE DUMMY READER MODE
+
+You are now in dummy reader mode of VOTE. Use the global function "scanCard" to scan a card. The function takes the card UID as the first (and only) parameter, and the UID can be both a string or a number.
+
+Usage: scanCard(123) // where 123 is the cardId `);
+        }
         // Open serial connections if they are not already open
-        if (!$rootScope.serialDevice && !$rootScope.ndef) {
+        if (
+          !$rootScope.serialDevice &&
+          !$rootScope.ndef &&
+          !$rootScope.dummyReader
+        ) {
           try {
             if (
               $window.navigator.userAgent.includes('Android') &&
@@ -107,7 +122,7 @@ module.exports = [
             const data = convertUID(serialNumber.split(':'));
             cb(data);
           };
-        } else if (!$rootScope.serialDevice) {
+        } else if ($rootScope.serialDevice) {
           let lastTime = 0;
           let lastData = 0;
           const onComplete = (input) => {


### PR DESCRIPTION
This adds web nfc support on modern Android devices. Registers the same
keys as the web serial one, with a few exceptions. Most should be
possible to deal with tho.

Our white cards works similar on both, and the data format is the same.

Makes it way easier to host a vote, since you only need one android device with nfc. Android devices can also be connected to an external monitor as well, making them a cheap and easy solution :100: 

Example of web nfc: https://googlechrome.github.io/samples/web-nfc/ 

### TODO
- [ ] ~Separate impl~ (Not sure we should/need to do it)
- [x] Make better gui for selecting input. (Nah, this works I guess)
- [x] Fix handling of NTNU-style cards in the old impl. Works in this one.
- [ ] Error handling when "bad" cards are being used (out of scope of this PR)
- [x] Make web serial and web nfc work with the same set of cards.