### PR TITLE
Fix env in PROD, and bumb versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: default
 
 steps:
   - name: setup
-    image: node:13
+    image: node:14
     when:
       event:
         - push
@@ -16,7 +16,7 @@ steps:
       - clone
 
   - name: lint
-    image: node:13
+    image: node:14
     when:
       event:
         - push
@@ -27,7 +27,7 @@ steps:
       - yarn lint
 
   - name: test
-    image: node:13
+    image: node:14
     when:
       event:
         - push
@@ -38,7 +38,7 @@ steps:
       - MONGO_URL=mongodb://mongodb:27017/vote-test REDIS_URL=redis yarn mocha
 
   - name: coverage
-    image: node:13
+    image: node:14
     when:
       event:
         - pull_request
@@ -54,7 +54,7 @@ steps:
       COVERALLS_SERVICE_NUMBER: ${DRONE_BUILD_NUMBER}
 
   - name: build
-    image: node:13
+    image: node:14
     when:
       event:
         - push
@@ -114,7 +114,7 @@ steps:
 
 services:
   - name: mongodb
-    image: mongo:3.6
+    image: mongo:4.4
 
   - name: redis
-    image: redis:latest
+    image: redis:6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13
+FROM node:14-slim
 MAINTAINER Abakus Webkom <webkom@abakus.no>
 
 # Create app directory

--- a/app/digital/mail.js
+++ b/app/digital/mail.js
@@ -6,7 +6,8 @@ const path = require('path');
 let creds = {};
 let transporter = {};
 if (env.NODE_ENV === 'production') {
-  creds = require('./client_secret.json');
+  // Get google auth creds from env
+  creds = JSON.parse(Buffer.from(env.GOOGLE_AUTH, 'base64').toString());
   transporter = nodemailer.createTransport({
     host: 'smtp.gmail.com',
     port: 465,
@@ -32,7 +33,7 @@ exports.mailHandler = async (user, email) => {
 
   if (env.NODE_ENV === 'development') {
     console.log('MAIL IS NOT SENT IN DEVELOPMENT'); // eslint-disable-line no-console
-    return new Promise(function (res, rej) {
+    return new Promise(function (res, _) {
       console.log('username:', cleanUsername, 'password:', cleanPassword); // eslint-disable-line no-console
       res('');
     })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2'
 
 services:
   mongo:
-    image: mongo:3.6
+    image: mongo:4.4
     ports:
       - '127.0.0.1:27017:27017'
   redis:
-    image: redis:latest
+    image: redis:6.0
     ports:
       - '127.0.0.1:6379:6379'

--- a/env.js
+++ b/env.js
@@ -12,4 +12,6 @@ module.exports = {
   RAVEN_DSN: process.env.RAVEN_DSN,
   MONGO_URL: process.env.MONGO_URL || 'mongodb://localhost:27017/vote',
   REDIS_URL: process.env.REDIS_URL || 'localhost',
+  // Mail auth
+  GOOGLE_AUTH: process.env.GOOGLE_AUTH || '',
 };


### PR DESCRIPTION
I have been using `mongo:4.4` and `node:14` the whole time 🤷🏻 . Might as well put it up in `:develop` while we are testing things online. 
The image of VOTE running in prod right now is the one build on this Dockerfile (as I built it manually.)