### PR TITLE
More user gen mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ $ yarn start
   - Url to the main icon on all pages
   - `default`: `/static/images/Abakule.jpg`
 - `LOGO_SRC` _(optional)_
-  - Url to the main logo
-  - `default`: `/static/images/Abakus_logo.png`
+  - External email to url to the main logo
+  - `default`: `https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png`
 - `COOKIE_SECRET`
   - **IMPORTANT** to change this to a secret value in production!!
   - `default`: in dev: `localsecret`, otherwise empty

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ $ yarn start
 - `ICON_SRC` _(optional)_
   - Url to the main icon on all pages
   - `default`: `/static/images/Abakule.jpg`
-- `LOGO_SRC` _(optional)_
-  - External email to url to the main logo
-  - `default`: `https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png`
 - `COOKIE_SECRET`
   - **IMPORTANT** to change this to a secret value in production!!
   - `default`: in dev: `localsecret`, otherwise empty
@@ -79,7 +76,7 @@ See `app.js` and `env.js` for the rest
 
 ```bash
 $ yarn build
-$ ICON_SRC=https://someicon.png LOGO_SRC=https://somelogo.png NODE_ENV=production GOOGLE_AUTH=base64encoding yarn start
+$ ICON_SRC=https://some-domain/image.png NODE_ENV=production GOOGLE_AUTH=base64encoding yarn start
 ```
 
 ## Using the card-readers

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ $ yarn start
 - `REDIS_URL`
   - Hostname of the redis server
   - `default`: `localhost`
-- `LOGO_SRC` _(optional)_
-  - Url to the main logo on all pages
+- `ICON_SRC` _(optional)_
+  - Url to the main icon on all pages
   - `default`: `/static/images/Abakule.jpg`
+- `LOGO_SRC` _(optional)_
+  - Url to the main logo
+  - `default`: `/static/images/Abakus_logo.png`
 - `COOKIE_SECRET`
   - **IMPORTANT** to change this to a secret value in production!!
   - `default`: in dev: `localsecret`, otherwise empty
@@ -71,7 +74,7 @@ See `app.js` and `env.js` for the rest
 
 ```bash
 $ yarn build
-$ LOGO_SRC=https://my-domain.tld/logo.png NODE_ENV=production GOOGLE_AUTH=base64encoding yarn start
+$ ICON_SRC=https://someicon.png LOGO_SRC=https://somelogo.png NODE_ENV=production GOOGLE_AUTH=base64encoding yarn start
 ```
 
 ## Using the card-readers

--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ $ yarn start
 - `COOKIE_SECRET`
   - **IMPORTANT** to change this to a secret value in production!!
   - `default`: in dev: `localsecret`, otherwise empty
+- `FRONTEND_URL`
+  - The site where vote should run
+  - `defualt`: `http://localhost:3000`
+- `FROM`
+  - The name we send mail from
+  - `default`: `Abakus`
+- `FROM_MAIL`
+  - The email we send mail from
+  - `default`: `admin@abakus.no`
+- `SMTP_URL`
+  - An SMTP connection string of the form `smtps://username:password@smtp.example.com/?pool=true`
 - `GOOGLE_AUTH`
-  - A base64 encoded string with the json data of a service account that can send mail. We also store
-    the `abakus_from_email` in the data object. Note that the `GOOGLE_AUTH` variable is only used when
-    VOTE is running in production, in development the `ETHERAL` variable can be used.
-- `ETHEREAL`
-  - A optional variable you can set that allows emails to be routed to a test `smtp` server. This is
-    useful if you intend to make changes to the way emails are sent, or the way the template looks.
-    The variable must be on the format `user:pass`, that you can find [here](https://ethereal.email/create).
+  - A base64 encoded string with the json data of a service account that can send mail.
 
 See `app.js` and `env.js` for the rest
 

--- a/app.js
+++ b/app.js
@@ -67,10 +67,10 @@ app.use(
     resave: false,
   })
 );
-const { LOGO_SRC, NODE_ENV } = env;
+const { ICON_SRC, NODE_ENV } = env;
 app.locals = Object.assign({}, app.locals, {
   NODE_ENV,
-  LOGO_SRC,
+  ICON_SRC,
 });
 
 /* istanbul ignore if */

--- a/app/controllers/election.js
+++ b/app/controllers/election.js
@@ -99,7 +99,7 @@ function setElectionStatus(req, res, active) {
 exports.activate = async (req, res) => {
   const otherActiveElection = await Election.findOne({ active: true });
   if (otherActiveElection) {
-    throw new errors.AllreadyActiveElectionError();
+    throw new errors.AlreadyActiveElectionError();
   }
   return setElectionStatus(req, res, true).then((election) => {
     const io = app.get('io');

--- a/app/digital/mail.js
+++ b/app/digital/mail.js
@@ -17,7 +17,7 @@ if (env.GOOGLE_AUTH) {
     secure: true,
     auth: {
       type: 'OAuth2',
-      user: process.env.FROM_MAIL,
+      user: env.FROM_MAIL,
       serviceClient: creds.client_id,
       privateKey: creds.private_key,
     },
@@ -54,7 +54,7 @@ exports.mailHandler = async (action, data) => {
   password = password && password.replace(/\W/g, '');
 
   let replacements = {
-    logo: env.LOGO_SRC,
+    from: env.FROM,
     username,
     password,
     link: `${env.FRONTEND_URL}/auth/login?token=${username}:${password}:`,
@@ -89,7 +89,10 @@ exports.mailHandler = async (action, data) => {
   // works even tho we dont use it.
   if (!transporter) {
     return new Promise(function (resolve, _) {
-      console.log('MAIL:', action, data); // eslint-disable-line no-console
+      // Don't log all the console mail when running tests
+      if (process.env.NODE_ENV != 'test') {
+        console.log('MAIL:', action, data); // eslint-disable-line no-console
+      }
       resolve('Done');
     });
   }

--- a/app/digital/template.html
+++ b/app/digital/template.html
@@ -223,10 +223,7 @@
                   <table cellpadding="0" cellspacing="0" width="600" class="w320">
                     <tr>
                       <td class="pull-left mobile-header-padding-left" style="vertical-align: middle;">
-                        <a href=""><img width="150" height="30" src="https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png"></a>
-                      </td>
-                      <td class="pull-right mobile-header-padding-right" style="color: #4d4d4d;">
-                        <a href="https://www.facebook.com/AbakusNTNU"><img width="38" height="47" src="http://s3.amazonaws.com/swu-filepicker/LMPMj7JSRoCWypAvzaN3_social_09.gif"/></a>
+                        <a href=""><img height="60" src="{{logo}}"></a>
                       </td>
                     </tr>
                   </table>
@@ -242,39 +239,33 @@
       </td>
     </tr>
     <tr>
-    <td align="center" valign="top" width="100%" style="background-color: #f7f7f7;" class="content-padding">
-      <center>
-        <table cellspacing="0" cellpadding="0" width="600" class="w320">
-          <tr>
-            <td class="header-lg">
-              VOTE
-            </td>
-          </tr>
-          <h2>{{title}}</h2>
-        </table>
-        <p>{{description}}</p>
-        <hr/>
-        <p>{{username}}</p>
-        <p>{{password}}</p>
-        <hr/>
-        <a href="https://vote.abakus.no" target="_blank">Logg inn her</a>
-      </center>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" valign="top" width="100%" style="background-color: #ffffff;  border-top: 1px solid #e5e5e5;">
-      <center>
-        <table cellpadding="0" cellspacing="0" width="600" class="w320">
-          <tr>
-            <td style="padding: 25px 0 25px">
-              <strong>Abakus Linjeforening</strong><br />
-                <a mailto="webkom@abakus.no">webkom@abakus.no</a> <br />
-            </td>
-          </tr>
-        </table>
-      </center>
-    </td>
-  </tr>
-</table>
+      <td align="center" valign="top" width="100%" style="background-color: #f7f7f7;" class="content-padding">
+        <center>
+          <table cellspacing="0" cellpadding="0" width="600" class="w320">
+            <tr>
+              <td class="header-lg">
+                VOTE
+              </td>
+            </tr>
+            <h2>{{title}}</h2>
+          </table>
+          <p>{{description}}</p>
+          {{#if new}}
+          <p>Dette er din digitale bruker. Under finner du brukernavn og passord.</p>
+          <hr/>
+          <p><b>Brukernavn: </b>{{username}}</p>
+          <p><b>Password: </b>{{password}}</p>
+          <a class="btn-primary" style="background-color:#c0392b;border-radius:5px;color:#ffffff;display:inline-block;font-family:'Cabin', Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;line-height:45px;text-align:center;text-decoration:none;width:155px;-webkit-text-size-adjust:none;mso-hide:all;" href={{link}} target="_blank"> Logg inn </a>
+          <hr/>
+          {{/if}}
+          {{#unless new}}
+          <hr/>
+          <p>Du har allerede motatt en bruker, og vi har registrert at du har klart å logge inn. Det vil si at du ikke vi få tilsendt en nytt brukernavn og passord. Ta kontakt med webkom dersom du mener dette er feil.
+          <hr/>
+          {{/unless}}
+        </center>
+      </td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/app/digital/template.html
+++ b/app/digital/template.html
@@ -148,12 +148,6 @@
         width: 320px !important;
       }
 
-      img[class="force-width-gmail"] {
-        display: none !important;
-        width: 0 !important;
-        height: 0 !important;
-      }
-
       a[class="button-width"],
       a[class="button-mobile"] {
         width: 248px !important;
@@ -196,11 +190,6 @@
         width: 280px !important;
         padding-bottom: 40px !important;
       }
-
-      td[class="info-img"],
-      img[class="info-img"] {
-        width: 278px !important;
-      }
     }
   </style>
 </head>
@@ -208,43 +197,12 @@
 <body bgcolor="#ffffff">
   <table align="center" cellpadding="0" cellspacing="0" class="container-for-gmail-android" width="100%">
     <tr>
-      <td align="left" valign="top" width="100%" style="background:repeat-x url(http://s3.amazonaws.com/swu-filepicker/4E687TRe69Ld95IDWyEg_bg_top_02.jpg) #ffffff;">
-        <center>
-        <img src="http://s3.amazonaws.com/swu-filepicker/SBb2fQPrQ5ezxmqUTgCr_transparent.png" class="force-width-gmail">
-          <table cellspacing="0" cellpadding="0" width="100%" bgcolor="#ffffff" background="http://s3.amazonaws.com/swu-filepicker/4E687TRe69Ld95IDWyEg_bg_top_02.jpg" style="background-color:transparent">
-            <tr>
-              <td width="100%" height="80" valign="top" style="text-align: center; vertical-align:middle;">
-              <!--[if gte mso 9]>
-              <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:80px; v-text-anchor:middle;">
-                <v:fill type="tile" src="http://s3.amazonaws.com/swu-filepicker/4E687TRe69Ld95IDWyEg_bg_top_02.jpg" color="#ffffff" />
-                <v:textbox inset="0,0,0,0">
-              <![endif]-->
-                <center>
-                  <table cellpadding="0" cellspacing="0" width="600" class="w320">
-                    <tr>
-                      <td class="pull-left mobile-header-padding-left" style="vertical-align: middle;">
-                        <a href=""><img height="60" src="{{logo}}"></a>
-                      </td>
-                    </tr>
-                  </table>
-                </center>
-                <!--[if gte mso 9]>
-                </v:textbox>
-              </v:rect>
-              <![endif]-->
-              </td>
-            </tr>
-          </table>
-        </center>
-      </td>
-    </tr>
-    <tr>
       <td align="center" valign="top" width="100%" style="background-color: #f7f7f7;" class="content-padding">
         <center>
           <table cellspacing="0" cellpadding="0" width="600" class="w320">
             <tr>
               <td class="header-lg">
-                VOTE
+                {{from}} - VOTE
               </td>
             </tr>
             <h2>{{title}}</h2>

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -225,6 +225,17 @@ class AllreadyActiveElectionError extends Error {
 
 exports.AllreadyActiveElectionError = AllreadyActiveElectionError;
 
+class MailError extends Error {
+  constructor(err) {
+    super();
+    this.name = 'MailError';
+    this.message = `Something went wrong with the email. Err: ${err}`;
+    this.status = 500;
+  }
+}
+
+exports.MailError = MailError;
+
 exports.handleError = (res, err, status) => {
   const statusCode = status || err.status || 500;
   return res.status(statusCode).json(

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -214,16 +214,16 @@ class DuplicateLegoUserError extends Error {
 
 exports.DuplicateLegoUserError = DuplicateLegoUserError;
 
-class AllreadyActiveElectionError extends Error {
+class AlreadyActiveElectionError extends Error {
   constructor() {
     super();
-    this.name = 'AllreadyActiveElection';
-    this.message = 'There is allready an active election';
+    this.name = 'AlreadyActiveElection';
+    this.message = 'There is already an active election';
     this.status = 409;
   }
 }
 
-exports.AllreadyActiveElectionError = AllreadyActiveElectionError;
+exports.AlreadyActiveElectionError = AlreadyActiveElectionError;
 
 class MailError extends Error {
   constructor(err) {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -38,8 +38,7 @@ const userSchema = new Schema({
 });
 
 userSchema.pre('save', function (next) {
-  // Usernames are case-insensitive, so store them
-  // in lowercase:
+  // Usernames are case-insensitive, so store them in lowercase:
   this.username = this.username.toLowerCase();
   next();
 });

--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -23,7 +23,7 @@ html(ng-app='voteApp')
     header
       .container
         .row.header: .col-xs-12
-          img(src=LOGO_SRC)
+          img(src=ICON_SRC)
           span vote
 
         .row: block navbar

--- a/app/views/partials/admin/editElection.pug
+++ b/app/views/partials/admin/editElection.pug
@@ -6,9 +6,9 @@
       h3 Tilgangskode:
         span.access-code.mono {{ election.accessCode }}
         i.fa.fa-copy.copy-icon.cs-tooltip(
-          ng-click="copyToClipboard(election.accessCode)"
-          )
-            .cs-tooltiptext {{ copySuccess ? "Kopiert!" : "Kopier" }}
+          ng-click='copyToClipboard(election.accessCode)'
+        )
+          .cs-tooltiptext {{ copySuccess ? "Kopiert!" : "Kopier" }}
 
     .election-info.admin
       h3.user-status

--- a/client/controllers/generateUserCtrl.js
+++ b/client/controllers/generateUserCtrl.js
@@ -9,22 +9,17 @@ module.exports = [
       userService.generateUser(user).then(
         function (response) {
           alertService.addSuccess(
-            `Bruker generert/oppdatert for ${response.data}!`
+            `Bruker ${response.data.user} ble ${response.data.status}!`
           );
           $scope.user = {};
           $scope.pending = false;
         },
         function (response) {
           $scope.pending = false;
-          switch (response.data.name) {
-            case 'DuplicateLegoUserError':
+          switch (response.status) {
+            case 409:
               alertService.addError(
                 'Denne LEGO brukern har allerede fått en bruker.'
-              );
-              break;
-            case 'DuplicateCardError':
-              alertService.addError(
-                'Dette kortet er allerede blitt registrert.'
               );
               break;
             default:

--- a/client/controllers/generateUserCtrl.js
+++ b/client/controllers/generateUserCtrl.js
@@ -19,7 +19,7 @@ module.exports = [
           switch (response.status) {
             case 409:
               alertService.addError(
-                'Denne LEGO brukern har allerede fått en bruker.'
+                'Denne LEGO brukeren har allerede fått en bruker.'
               );
               break;
             default:

--- a/client/login.js
+++ b/client/login.js
@@ -4,26 +4,30 @@ import QrScannerWorkerPath from '!!file-loader!qr-scanner/qr-scanner-worker.min.
 QrScanner.WORKER_PATH = QrScannerWorkerPath;
 if ('addEventListener' in document) {
   document.addEventListener('DOMContentLoaded', function () {
+    // Get the token string form the url, on the format username:password:code
     const getTokenFromUrl = (url) => {
       const urlParams = new URLSearchParams(getLocation(url).search);
       return urlParams.get('token');
     };
+
+    // Helper function
     const getLocation = function (href) {
       var l = document.createElement('a');
       l.href = href;
       return l;
     };
-    const doTokenThing = (url) => {
+
+    // Parse and insert values from token
+    const parseAndUseToken = (url) => {
       try {
         const [u, p, code] = getTokenFromUrl(url).split(':');
+        document.querySelector('[name=username]').value = u;
+        document.querySelector('[name=username]').style.textAlign = 'center';
+
         document.querySelector('[name=password]').value = p;
         document.querySelector('[name=password]').type = 'text';
+        document.querySelector('[name=password]').style.textAlign = 'center';
 
-        document.querySelector('#alertInfo').setAttribute('class', '');
-
-        document.querySelector('[name=usingToken]').value = true;
-
-        document.querySelector('[name=username]').value = u;
         document
           .querySelector('[name=username]')
           .setAttribute('readonly', 'readonly');
@@ -32,41 +36,48 @@ if ('addEventListener' in document) {
           .querySelector('[name=password]')
           .setAttribute('readonly', 'readonly');
 
-        document.querySelector('[type=submit]').style.display = 'none';
-        document.querySelector('#testing').style.display = 'none';
+        // If the user gets token from mail the code will be ""
+        if (code) {
+          document.querySelector('#alertInfo').setAttribute('class', '');
+          document.querySelector('[name=usingToken]').value = true;
+          document.querySelector('[type=submit]').style.display = 'none';
+          document.querySelector('#testing').style.display = 'none';
 
-        document
-          .querySelector('[id=confirmScreenshot]')
-          .setAttribute('class', '');
-        document.querySelector('[id=confirmScreenshot]').onclick = function (
-          e
-        ) {
-          e.target.setAttribute('class', 'hidden');
-          document.querySelector('[type=submit]').style.display = '';
-        };
+          document
+            .querySelector('[id=confirmScreenshot]')
+            .setAttribute('class', '');
+          document.querySelector('[id=confirmScreenshot]').onclick = function (
+            e
+          ) {
+            e.target.setAttribute('class', 'hidden');
+            document.querySelector('[type=submit]').style.display = '';
+          };
 
-        fetch('/api/qr/open/?code=' + code);
-        QRCode.toDataURL(url, { type: 'image/png', width: 300 }, function (
-          err,
-          url
-        ) {
-          document.querySelector('[id=qrImg]').setAttribute('src', url);
-        });
+          fetch('/api/qr/open/?code=' + code);
+          QRCode.toDataURL(url, { type: 'image/png', width: 300 }, function (
+            err,
+            url
+          ) {
+            document.querySelector('[id=qrImg]').setAttribute('src', url);
+          });
+        }
       } catch (e) {
         alert('Det skjedde en feil. Prøv på nytt');
         /* eslint no-console: 0 */
         console.warn('Unable to decode token: ', e);
       }
     };
+
+    // Get token
     const token = getTokenFromUrl(window.location.href);
     if (token) {
-      doTokenThing(window.location.href);
+      parseAndUseToken(window.location.href);
     } else {
       QrScanner.hasCamera();
       const qrScanner = new QrScanner(
         document.getElementById('testing'),
         (result) => {
-          doTokenThing(result);
+          parseAndUseToken(result);
         }
       );
       qrScanner.start();

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       MONGO_URL: 'mongodb://mongo:27017/vote'
       REDIS_URL: 'redis'
       COOKIE_SECRET: 'long-secret-here-is-important'
-      LOGO_SRC: 'https://raw.githubusercontent.com/webkom/lego/master/assets/abakus_webkom.png'
       ICON_SRC: 'https://raw.githubusercontent.com/webkom/lego/master/assets/abakus_webkom.png'
       FROM: 'YourCompany'
       FROM_MAIL: "noreply@example.com"

--- a/env.js
+++ b/env.js
@@ -1,6 +1,9 @@
 module.exports = {
   // URL/source to the logo on all pages
-  LOGO_SRC: process.env.LOGO_SRC || '/static/images/Abakule.jpg',
+  ICON_SRC: process.env.ICON_SRC || '/static/images/Abakule.jpg',
+  LOGO_SRC:
+    process.env.LOGO_SRC ||
+    'https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png',
   // Node environment. 'development' or 'production'
   NODE_ENV: process.env.NODE_ENV || 'development',
   // This cannot be empty when running in production
@@ -15,4 +18,6 @@ module.exports = {
   GOOGLE_FROM_MAIL: process.env.GOOGLE_FROM_MAIL || '',
   // Dev mail auth
   ETHEREAL: process.env.ETHEREAL,
+  //
+  FRONTEND_URL: process.env.FRONTEND_URL || 'http://localhost:3000',
 };

--- a/env.js
+++ b/env.js
@@ -1,9 +1,6 @@
 module.exports = {
   // URL/source to the logo on all pages
   ICON_SRC: process.env.ICON_SRC || '/static/images/Abakule.jpg',
-  LOGO_SRC:
-    process.env.LOGO_SRC ||
-    'https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png',
   // Node environment. 'development' or 'production'
   NODE_ENV: process.env.NODE_ENV || 'development',
   // This cannot be empty when running in production

--- a/env.js
+++ b/env.js
@@ -13,11 +13,12 @@ module.exports = {
   HOST: process.env.HOST || 'localhost',
   MONGO_URL: process.env.MONGO_URL || 'mongodb://localhost:27017/vote',
   REDIS_URL: process.env.REDIS_URL || 'localhost',
-  // Mail auth
-  GOOGLE_AUTH: process.env.GOOGLE_AUTH,
-  GOOGLE_FROM_MAIL: process.env.GOOGLE_FROM_MAIL || '',
-  // Dev mail auth
-  ETHEREAL: process.env.ETHEREAL,
-  //
   FRONTEND_URL: process.env.FRONTEND_URL || 'http://localhost:3000',
+
+  // Mail settings
+  FROM: process.env.FROM || 'Abakus',
+  FROM_MAIL: process.env.FROM_MAIL || 'admin@abakus.no',
+  // Use one of the below
+  GOOGLE_AUTH: process.env.GOOGLE_AUTH,
+  SMTP_URL: process.env.SMTP_URL,
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,13 +4,14 @@ const Alternative = require('../app/models/alternative');
 const Election = require('../app/models/election');
 const Vote = require('../app/models/vote');
 const User = require('../app/models/user');
+const Register = require('../app/models/register');
 const crypto = require('crypto');
 
 exports.dropDatabase = () =>
   mongoose.connection.dropDatabase().then(() => mongoose.disconnect());
 
 exports.clearCollections = () =>
-  Bluebird.map([Alternative, Election, Vote, User], (collection) =>
+  Bluebird.map([Alternative, Register, Election, Vote, User], (collection) =>
     collection.deleteMany()
   );
 


### PR DESCRIPTION
Resolved: #393 
Resolves: #399 


# Improve the mail and user generation

This change fixes a bunch of the mail and user generation problems we had.
- Include "username" and "password" in the mail template so people understand what is what
- Make the "Logg inn" link into a button
- Make the "Logg inn" href an `ENV` so it can be changed
- Add the `username` and `password` as a `?token=` query param. This is on the same schema as the QR version, so we can reuse that code for autofill
- Remove some links from the template to try to avoid `thrash` and `commercial` tags in inboxes.
- Make the mail-handler and user-gen toss some better errors, and add tests to make sure everything works as expected.
- Add support for -3- different `transporter` objects. 
  - The default is just a promise, so the mail works without any other stuff. 
  - The second one is a basic `STMP` transporter, which takes a connection string, and can connect to any basic stmp server with a username and a password. 
  - The last is the `GOOGLE_AUTH` transporter, which takes a`base64` encoded service account from google.