### PR TITLE
Reuse ballot confirmation component on receipt page

### DIFF
--- a/app/views/partials/retrieveVote.pug
+++ b/app/views/partials/retrieveVote.pug
@@ -20,9 +20,13 @@
     ) Hent avstemning
 
   .text-center.vote-result-feedback(ng-if='vote')
-    h4 Din prioritering på: {{ vote.election.title }}
-    table.table.mono
-      tbody
-        tr(ng-repeat='priority in vote.priorities')
-          th.th-right Prioritering {{ $index + 1 }}:
-          th.th-left {{ priority.description }}
+    h3 Din prioritering på: {{ vote.election.title }}
+    .confirmVotes(ng-switch='vote.priorities.length === 0')
+      .ballot
+        div(ng-switch-when='true')
+          h3 Blank stemme
+          i Din stemme vil fortsatt påvirke hvor mange stemmer som kreves for å vinne
+        div(ng-switch-when='false')
+          ol
+            li.confirm-pri(ng-repeat='alternative in vote.priorities')
+              p {{ alternative.description }}

--- a/client/styles/election.styl
+++ b/client/styles/election.styl
@@ -151,6 +151,7 @@
             line-height 40px
 
             p
+                text-transform uppercase
                 vertical-align middle
                 margin 0
 


### PR DESCRIPTION
The receipt now looks like this:
![image](https://user-images.githubusercontent.com/42850232/106741842-887ddf00-661c-11eb-89ea-2dbaeb927cfd.png)

The text on the ballot is also uppercased on the ballot to match the look when prioritizing alternatives for an election.
