### PR TITLE
Fix edit election page to match new alternatives styles

### DIFF
--- a/app/views/partials/admin/editElection.pug
+++ b/app/views/partials/admin/editElection.pug
@@ -3,7 +3,12 @@
     .election-info.admin
       h2 {{ election.title }}
       p {{ election.description }}
-      h3 Tilgangskode: {{ election.accessCode }}
+      h3 Tilgangskode:
+        span.access-code.mono {{ election.accessCode }}
+        i.fa.fa-copy.copy-icon.cs-tooltip(
+          ng-click="copyToClipboard(election.accessCode)"
+          )
+            .cs-tooltiptext {{ copySuccess ? "Kopiert!" : "Kopier" }}
 
     .election-info.admin
       h3.user-status
@@ -22,7 +27,9 @@
 
       ul.list-unstyled
         li(ng-repeat='alternative in election.alternatives')
-          p {{ alternative.description }}
+          .content
+            div
+              p {{ alternative.description }}
 
       form.add-alternative.form-group(
         name='alternativeForm',

--- a/client/controllers/editElectionCtrl.js
+++ b/client/controllers/editElectionCtrl.js
@@ -139,5 +139,21 @@ module.exports = [
         .path('/admin/create_election')
         .search({ election: JSON.stringify(election) });
     };
+
+    $scope.copyToClipboard = function (text) {
+      const copyEl = document.createElement('textarea');
+      copyEl.style.opacity = '0';
+      copyEl.style.position = 'fixed';
+      copyEl.textContent = text;
+      document.body.appendChild(copyEl);
+      copyEl.select();
+      try {
+        document.execCommand('copy');
+        $scope.copySuccess = true;
+        setTimeout(() => ($scope.copySuccess = null), 1000);
+      } finally {
+        document.body.removeChild(copyEl);
+      }
+    };
   },
 ];

--- a/client/styles/admin.styl
+++ b/client/styles/admin.styl
@@ -56,6 +56,19 @@ form
         cursor pointer
         color $abakus-dark
 
+span.access-code
+    font-weight 800
+    font-size 30px
+    padding-left 15px
+
+.copy-icon
+    font-size initial
+    vertical-align middle
+    cursor pointer
+
+    &:hover
+        color $abakus-light
+
 .alternatives.admin
     padding-top 10px
     margin-bottom 0
@@ -67,6 +80,7 @@ form
         &:hover
             cursor default
             background-color alpha($alternative-background, 0.15)
+            box-shadow none
 
         span
             position absolute


### PR DESCRIPTION
closes #383 

Fixes admin edit election page to look like it should with the style changes added.
- Also makes the access code a little more visible
- And adds a little gimmick to copy the access code with an icon/button :grin:.

![image](https://user-images.githubusercontent.com/42850232/106745392-528f2980-6621-11eb-87de-877e662de764.png)
