### PR TITLE
Add view for normal election voting in addition to stv

### DIFF
--- a/app/views/partials/election.pug
+++ b/app/views/partials/election.pug
@@ -6,40 +6,66 @@
           h2 {{ activeElection.title }}
           p {{ activeElection.description }}
 
-        .alternatives
-          ul.list-unstyled
-            li(
-              ng-repeat='alternative in getPossibleAlternatives()',
-              ng-click='selectAlternative(alternative)'
-            )
-              .content
-                p {{ alternative.description }}
-              .icon.add(ng-click='deselectAlternative(alternative._id)')
-                i.fa.fa-plus
+        div(ng-switch='activeElection.type')
+          // STV election
+          // ---------------------------------------------------------------
+          div(ng-switch-when='stv')
+            .alternatives
+              ul.list-unstyled
+                li(
+                  ng-repeat='alternative in getPossibleAlternatives()',
+                  ng-click='selectAlternative(alternative)'
+                )
+                  .content
+                    p {{ alternative.description }}
+                  .icon.add(ng-click='deselectAlternative(alternative._id)')
+                    i.fa.fa-plus
 
-        .alternatives
-          h3 Din prioritering
-          p.helptext(ng-if='priorities.length == 0')
-            em Velg et alternativ fra listen
+            .alternatives
+              h3 Din prioritering
+              p.helptext(ng-if='priorities.length == 0')
+                em Velg et alternativ fra listen
 
-          ul.list-unstyled.numbered(
-            sortable,
-            sortable-on-update='updatePriority',
-            sortable-list='priorities',
-            sortable-animation='100',
-            sortable-delay='0',
-            sortable-handle='.content'
-          )
-            li(ng-repeat='alternative in priorities track by alternative._id')
-              .content
-                .drag
-                  i.fa.fa-bars
-                div
-                  p {{ alternative.description }}
-              .icon.remove(ng-click='deselectAlternative(alternative._id)')
-                i.fa.fa-close
+              ul.list-unstyled.numbered(
+                sortable,
+                sortable-on-update='updatePriority',
+                sortable-list='priorities',
+                sortable-animation='100',
+                sortable-delay='0',
+                sortable-handle='.content'
+              )
+                li(
+                  ng-repeat='alternative in priorities track by alternative._id'
+                )
+                  .content
+                    .drag
+                      i.fa.fa-bars
+                    div
+                      p {{ alternative.description }}
+                  .icon.remove(ng-click='deselectAlternative(alternative._id)')
+                    i.fa.fa-close
+          // -------------------------------------------------------------------
+
+          // NORMAL type election view
+          // -------------------------------------------------------------------
+          div(ng-switch-when='normal')
+            .alternatives
+              h3 Alternativer
+              ul.list-unstyled
+                li(
+                  ng-repeat='alternative in activeElection.alternatives',
+                  ng-click='toggleAlternative(alternative)'
+                )
+                  .content(ng-class='{"selected": isChosen(alternative)}')
+                    p {{ alternative.description }}
+
+          // -------------------------------------------------------------------
 
         button.btn.btn-lg.btn-default(type='button', ng-click='confirm()') {{ priorities.length === 0 ? "Stem Blank" : "Avgi stemme" }}
+
+        div
+
+        button.btn.btn-sm.btn-danger(type='button', ng-click='reset()') Reset
 
       div(ng-switch-when='true')
         h3 Bekreft din stemme

--- a/client/controllers/electionCtrl.js
+++ b/client/controllers/electionCtrl.js
@@ -89,6 +89,20 @@ module.exports = [
       $scope.priorities = $scope.priorities.filter((a) => a._id !== id);
     };
 
+    /**
+     * Toggle the chosen alternative. Will clear the priority list if the alternative is present.
+     * Otherwise will clear the list and add only the alternative to the list.
+     * The priority list will always contain only 1 element.
+     * @param {Object} alternative
+     */
+    $scope.toggleAlternative = function (alternative) {
+      if ($scope.priorities.find((a) => a._id === alternative._id))
+        $scope.priorities = [];
+      else {
+        $scope.priorities = [alternative];
+      }
+    };
+
     $scope.confirm = function () {
       $scope.confirmVote = true;
     };
@@ -147,6 +161,10 @@ module.exports = [
      */
     $scope.isChosen = function (alternative) {
       return $scope.priorities.includes(alternative);
+    };
+
+    $scope.reset = function () {
+      location.reload();
     };
   },
 ];


### PR DESCRIPTION
Fixes #435 

This is pretty much how the old view was before, but with the "new" styling and the confirmation page.
There is no difference in how the data is posted. (There is a list with only one alternative)

Also adds a reset button to the bottom that resets the users current voting state. (clears all alternatives and refetches the election.

![user-vote](https://user-images.githubusercontent.com/42850232/135732814-790bb00b-ab03-48a0-9882-e586138ccf45.gif)
