### PR TITLE
Bump chrome version to match circleci/node:16-browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier": "prettier '**/*.{js,ts,pug}' --write",
     "mocha": "NODE_ENV=test MONGO_URL=${MONGO_URL:-'mongodb://localhost:27017/vote-test'} nyc mocha test/**/*.test.js --exit --timeout 30000",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "protractor": "webdriver-manager update --standalone false --versions.chrome 93.0.4577.82 && NODE_ENV=protractor MONGO_URL=${MONGO_URL:-'mongodb://localhost:27017/vote-test'} protractor ./features/protractor-conf.js",
+    "protractor": "webdriver-manager update --standalone false --versions.chrome 94.0.4606.113 && NODE_ENV=protractor MONGO_URL=${MONGO_URL:-'mongodb://localhost:27017/vote-test'} protractor ./features/protractor-conf.js",
     "postinstall": "yarn build"
   },
   "prettier": {


### PR DESCRIPTION
Years ago, when struggling with protractor and CI, we configured this webdriver-manager forced update when 
running the E2E tests. This has worked great, but the chrome version has to be manually hardcoded. 

Since drone is configured to run on circleci/node:16-browsers we never know when they (circle) decide to 
upgrade their chrome version. I see now (from recent CI runs), that they have bumped their version, so we must 
do the same.

This is sub-optimal. I will create an issue about looking into this :)  
