### PR TITLE
Fix some deprecations warnings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,9 +4,11 @@
       "@babel/preset-typescript"
     ],
     ["@babel/preset-env", {
-      "useBuiltIns": "entry"
+      "useBuiltIns": "entry",
+      "corejs": "3.27"
     }]
   ],
   "plugins": [
-    "@babel/plugin-transform-runtime"]
+    "@babel/plugin-transform-runtime"
+  ]
 }

--- a/app.ts
+++ b/app.ts
@@ -29,6 +29,7 @@ app.set('view engine', 'pug');
 app.set('views', `${__dirname}/app/views`);
 app.set('mongourl', env.MONGO_URL);
 
+mongoose.set('strictQuery', true);
 mongoose.connect(app.get('mongourl'));
 
 raven.config(env.RAVEN_DSN).install();

--- a/bin/users.ts
+++ b/bin/users.ts
@@ -40,6 +40,7 @@ program
       { validator, retry: true },
       (modeErr, mode) => {
         const modeId = parseInt(mode);
+        mongoose.set('strictQuery', true);
         mongoose.connect(mongoURL, {}, (connectErr) => {
           if (connectErr) return done(connectErr, null);
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "chai-as-promised": "7.1.1",
     "chai-subset": "1.6.0",
     "copy-webpack-plugin": "11.0.0",
-    "core-js": "2.6.12",
+    "core-js": "3.27.1",
     "coveralls": "3.0.9",
     "cucumber": "0.10.3",
     "eslint": "7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,7 +3685,12 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2:
     browserslist "^4.17.5"
     semver "7.0.0"
 
-core-js@2.6.12, core-js@^2.4.1:
+core-js@3.27.1:
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.1.tgz#23cc909b315a6bb4e418bf40a52758af2103ba46"
+  integrity sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==
+
+core-js@^2.4.1:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==


### PR DESCRIPTION
Explicitly set mongoose strictQuery to true. This will be default false
in the next release.
Upgrade and specify the core-js version for babel as per their warning.
