### PR TITLE
Add feature to sync script to register all users.

### DIFF
--- a/deployment/sync/README.md
+++ b/deployment/sync/README.md
@@ -2,16 +2,23 @@
 
 This use a websocket connection from LEGO and create new VOTE users when a user registers on an event.
 
+You can also run with `-init` to run a complete sync of all users registered to the event. Just put
+a dummy value for the `-socket-url` in this instance.
+
 ```
 Usage of ./sync:
   -csrf-token string
         A csrf token from VOTE. Look in a request. On the format: "RaNdom-String"
   -event int
         Event id to make users from. On the format: 123
-  -lego-user-endpoint string
-        Endpoint to users on LEGO. On the format: "https://lego-domain.no/api/v1/users/"
+  -init
+        Run a complete sync. Will get all emails from registration and register to vote
+  -lego-endpoint string
+        Endpoint to api on LEGO. On the format: "https://lego-domain.no/api/v1/"
+  -lego-token string
+        Lego bearer token here. Look in the header of a request to lego api.
   -socket-url string
-        Websocket url, full url w/token. Look in console on abakus.no. On the format: "wss://ws.abakus-domain.no/?jwt=long-jwt-here"
+        Websocket url, full url w/token. Look in console on abakus.no. On the format: "wss://ws.abakus-domain.no/?jwt=long-bearer-here"
   -vote-cookie string
         Vote session cookie. On the format: "connect.sid=xasda"
   -vote-endpoint string

--- a/deployment/sync/main.go
+++ b/deployment/sync/main.go
@@ -12,17 +12,20 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
 
 var eventId = flag.Int("event", 0, "Event id to make users from. On the format: 123")
-var wsUrl = flag.String("socket-url", "", `Websocket url, full url w/token. Look in console on abakus.no. On the format: "wss://ws.abakus-domain.no/?jwt=long-jwt-here"`)
+var wsUrl = flag.String("socket-url", "", `Websocket url, full url w/token. Look in console on abakus.no. On the format: "wss://ws.abakus-domain.no/?jwt=long-bearer-here"`)
+var lego_token = flag.String("lego-token", "", "Lego bearer token here. Look in the header of a request to lego api.")
 var authCookieVote = flag.String("vote-cookie", "", `Vote session cookie. On the format: "connect.sid=xasda"`)
 var csrfToken = flag.String("csrf-token", "", `A csrf token from VOTE. Look in a request. On the format: "RaNdom-String" `)
 var voteEndpoint = flag.String("vote-endpoint", "", `Endpoint to VOTE generate. On the format: "https://vote.abakus-domain.no/api/user/generate"`)
-var legoUserEndpont = flag.String("lego-user-endpoint", "", `Endpoint to users on LEGO. On the format: "https://lego-domain.no/api/v1/users/"`)
+var legoEndpoint = flag.String("lego-endpoint", "", `Endpoint to api on LEGO. On the format: "https://lego-domain.no/api/v1/"`)
+var initSync = flag.Bool("init", false, "Run a complete sync. Will get all emails from registration and register to vote")
 
 type LegoAction struct {
 	Type string `json:"type"`
@@ -34,21 +37,24 @@ type LegoRegisterAction struct {
 		FromPool       interface{} `json:"fromPool"`
 	} `json:"meta"`
 	Payload struct {
-		ID   int `json:"id"`
-		User struct {
-			ID                   int    `json:"id"`
-			Username             string `json:"username"`
-			FirstName            string `json:"firstName"`
-			LastName             string `json:"lastName"`
-			FullName             string `json:"fullName"`
-			Gender               string `json:"gender"`
-			ProfilePicture       string `json:"profilePicture"`
-			InternalEmailAddress string `json:"internalEmailAddress"`
-		} `json:"user"`
+		ID     int         `json:"id"`
+		User   LegoUser    `json:"user"`
 		Pool   interface{} `json:"pool"`
 		Status string      `json:"status"`
 	} `json:"payload"`
 }
+
+type LegoUser struct {
+	ID                   int    `json:"id"`
+	Username             string `json:"username"`
+	FirstName            string `json:"firstName"`
+	LastName             string `json:"lastName"`
+	FullName             string `json:"fullName"`
+	Gender               string `json:"gender"`
+	ProfilePicture       string `json:"profilePicture"`
+	InternalEmailAddress string `json:"internalEmailAddress"`
+}
+
 type LegoUnregisterAction struct {
 	Meta struct {
 		EventID        int         `json:"eventId"`
@@ -57,19 +63,19 @@ type LegoUnregisterAction struct {
 	} `json:"meta"`
 	Payload struct {
 		ID   int `json:"id"`
-		User struct {
-			ID                   int    `json:"id"`
-			Username             string `json:"username"`
-			FirstName            string `json:"firstName"`
-			LastName             string `json:"lastName"`
-			FullName             string `json:"fullName"`
-			Gender               string `json:"gender"`
-			ProfilePicture       string `json:"profilePicture"`
-			InternalEmailAddress string `json:"internalEmailAddress"`
-		} `json:"user"`
-		Pool   interface{} `json:"pool"`
-		Status string      `json:"status"`
+		User LegoUser
 	} `json:"payload"`
+}
+
+type EventRegistration struct {
+	ID     int      `json:"id"`
+	User   LegoUser `json:"user"`
+	Status string   `json:"status"`
+}
+
+type EventPool struct {
+	ID            int                 `json:"id"`
+	Registrations []EventRegistration `json:"registrations"`
 }
 
 func main() {
@@ -94,8 +100,16 @@ func main() {
 	if len(*voteEndpoint) == 0 {
 		log.Fatal("Missing authCookieVote")
 	}
-	if len(*legoUserEndpont) == 0 {
-		log.Fatal("Missing legoUserEndpoint")
+	if len(*lego_token) == 0 {
+		log.Fatal("Missing lego_token")
+	}
+	if len(*legoEndpoint) == 0 {
+		log.Fatal("Missing legoEndpoint")
+	}
+
+	if *initSync {
+		runOneSync()
+		os.Exit(0)
 	}
 
 	log.SetFlags(0)
@@ -104,10 +118,9 @@ func main() {
 	signal.Notify(interrupt, os.Interrupt)
 
 	u, _ := url.Parse(*wsUrl)
-	jwt := u.Query()["jwt"][0]
 
 	for {
-		err := runLegoToVoteSync(interrupt, u, jwt)
+		err := runLegoToVoteSync(interrupt, u)
 
 		// Exit if runLegoToVoteSync returns nil, otherwise reconnect
 		if err == nil {
@@ -118,7 +131,91 @@ func main() {
 	}
 
 }
-func runLegoToVoteSync(interrupt chan os.Signal, url *url.URL, jwt string) error {
+
+func getUserEmail(username string) (string, error) {
+
+	client := &http.Client{}
+
+	ctx, cnl := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cnl()
+
+	legoGet, err := http.NewRequestWithContext(ctx, "GET", *legoEndpoint+"users/"+username, nil)
+	if err != nil {
+		log.Printf("Error when creating lego user req: %e\n", err)
+		return "", err
+	}
+	legoGet.Header.Add("Authorization", "Bearer "+*lego_token)
+
+	resp, err := client.Do(legoGet)
+	if err != nil {
+		log.Printf("Error when fetching lego user: %e\n", err)
+		return "", err
+	}
+	var legoUserData struct {
+		Email string `json:"email"`
+	}
+	defer resp.Body.Close()
+	respData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error when reading lego user: %e\n", err)
+		return "", err
+	}
+
+	err = json.Unmarshal(respData, &legoUserData)
+
+	if err != nil {
+		log.Printf("Error when unmarshalling user: %e\n", err)
+		return "", err
+	}
+
+	return legoUserData.Email, nil
+}
+
+func registerUserInVote(userEmail string, username string) error {
+
+	client := &http.Client{}
+
+	voteFormData := struct {
+		Email      string `json:"email"`
+		Identifier string `json:"identifier"`
+	}{
+		Email:      userEmail,
+		Identifier: username,
+	}
+
+	out, err := json.Marshal(voteFormData)
+	if err != nil {
+		log.Printf("Error when marshalling user: %e\n", err)
+		return err
+	}
+
+	log.Printf("Posting to VOTE: %q", string(out))
+	req, err := http.NewRequest("POST", *voteEndpoint, bytes.NewBuffer(out))
+	if err != nil {
+		log.Printf("Error when creating VOTE req: %e\n", err)
+		return err
+	}
+	req.Header.Add("CSRF-Token", *csrfToken)
+	req.Header.Add("content-type", "application/json;charset=UTF-8")
+	req.Header.Set("Cookie", *authCookieVote)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Error when fetching VOTE: %e\n", err)
+		return err
+	}
+
+	defer resp.Body.Close()
+	respData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error when reading from vote: %e\n", err)
+		return err
+	}
+	log.Printf("Creating user returned: %s, %s\n", resp.Status, respData)
+	return nil
+}
+
+func runLegoToVoteSync(interrupt chan os.Signal, url *url.URL) error {
 	log.Printf("connecting to %s", url.String())
 
 	c, _, err := websocket.DefaultDialer.Dial(url.String(), nil)
@@ -158,77 +255,20 @@ func runLegoToVoteSync(interrupt chan os.Signal, url *url.URL, jwt string) error
 				}
 
 				log.Printf("Registering user %q in VOTE\n", action.Payload.User.FullName)
-				client := &http.Client{}
 
-				ctx, cnl := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cnl()
+				userEmail, err := getUserEmail(action.Payload.User.Username)
 
-				legoGet, err := http.NewRequestWithContext(ctx, "GET", *legoUserEndpont+action.Payload.User.Username, nil)
 				if err != nil {
-					log.Printf("Error when creating lego user req: %e\n", err)
-					break
-				}
-				legoGet.Header.Add("Authorization", "JWT "+jwt)
-
-				resp, err := client.Do(legoGet)
-				if err != nil {
-					log.Printf("Error when fetching lego user: %e\n", err)
-					break
-				}
-				var legoUserData struct {
-					Email string `json:"email"`
-				}
-				defer resp.Body.Close()
-				respData, err := ioutil.ReadAll(resp.Body)
-				if err != nil {
-					log.Printf("Error when reading lego user: %e\n", err)
+					log.Printf("Error while retrieving user email: %e\n", err)
 					break
 				}
 
-				err = json.Unmarshal(respData, &legoUserData)
+				err = registerUserInVote(userEmail, action.Payload.User.Username)
 
 				if err != nil {
-					log.Printf("Error when unmarshalling user: %e\n", err)
+					log.Printf("Error while registering user in vote: %e\n", err)
 					break
 				}
-
-				voteFormData := struct {
-					Email      string `json:"email"`
-					Identifier string `json:"identifier"`
-				}{
-					Email:      legoUserData.Email,
-					Identifier: action.Payload.User.Username,
-				}
-
-				out, err := json.Marshal(voteFormData)
-				if err != nil {
-					log.Printf("Error when marshalling user: %e\n", err)
-					break
-				}
-
-				log.Printf("Posting to VOTE: %q", string(out))
-				req, err := http.NewRequest("POST", *voteEndpoint, bytes.NewBuffer(out))
-				if err != nil {
-					log.Printf("Error when creating VOTE req: %e\n", err)
-					break
-				}
-				req.Header.Add("CSRF-Token", *csrfToken)
-				req.Header.Add("content-type", "application/json;charset=UTF-8")
-				req.Header.Set("Cookie", *authCookieVote)
-
-				resp, err = client.Do(req)
-				if err != nil {
-					log.Printf("Error when fetching VOTE: %e\n", err)
-					break
-				}
-
-				defer resp.Body.Close()
-				respData, err = ioutil.ReadAll(resp.Body)
-				if err != nil {
-					log.Printf("Error when reading from vote: %e\n", err)
-					break
-				}
-				log.Printf("Creating user returned: %s, %s\n", resp.Status, respData)
 
 			case "Event.SOCKET_UNREGISTRATION.SUCCESS":
 				var action LegoUnregisterAction
@@ -276,4 +316,66 @@ func runLegoToVoteSync(interrupt chan os.Signal, url *url.URL, jwt string) error
 		}
 	}
 
+}
+
+func runOneSync() error {
+
+	client := &http.Client{}
+
+	ctx, cnl := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cnl()
+
+	legoGet, err := http.NewRequestWithContext(ctx, "GET", *legoEndpoint+"events/"+strconv.Itoa(*eventId)+"/administrate", nil)
+	if err != nil {
+		log.Printf("Error when creating lego event req: %e\n", err)
+		return err
+	}
+	legoGet.Header.Add("Authorization", "Bearer "+*lego_token)
+
+	resp, err := client.Do(legoGet)
+	if err != nil {
+		log.Printf("Error when fetching lego user: %e\n", err)
+		return err
+	}
+
+	var legoEventData struct {
+		Pools []EventPool `json:"pools"`
+	}
+
+	defer resp.Body.Close()
+	respData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error when reading lego user: %e\n", err)
+		return err
+	}
+
+	err = json.Unmarshal(respData, &legoEventData)
+
+	if err != nil {
+		log.Fatal("Error while unmarshalling event data")
+	}
+
+	for _, pool := range legoEventData.Pools {
+		for _, reg := range pool.Registrations {
+			if reg.Status == "SUCCESS_REGISTER" {
+				userEmail, err := getUserEmail(reg.User.Username)
+
+				if err != nil {
+					log.Printf("Error while retrieving user email: %e\n", err)
+					continue
+				}
+
+				log.Printf("user email to be registered: %s", userEmail)
+
+				err = registerUserInVote(userEmail, reg.User.Username)
+
+				if err != nil {
+					log.Printf("Error while registering user in vote: %e\n", err)
+					continue
+				}
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This adds the `-init` option to the sync script that will loop over all
registrations on the event and register the users in vote. E.x. run this
once, and then run without `-init` to only listen to incoming
websockets.
