### PR TITLE
Remove unnecessary steps from deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,8 @@ steps:
     when:
       event:
         - push
+      branch:
+        exclude: [prod]
     depends_on:
       - setup
     commands:
@@ -37,21 +39,6 @@ steps:
     commands:
       - yarn build
       - yarn build:cli
-
-  # - name: test
-  #   image: node:16-alpine
-  #   when:
-  #     event:
-  #       - push
-  #   depends_on:
-  #     - build
-  #   commands:
-  #     - yarn coverage
-  #   environment:
-  #     MONGO_URL: mongodb://mongodb:27017/vote-test
-  #     REDIS_URL: redis
-  #     VITEST_MAX_THREADS: 8
-  #     VITEST_MIN_THREADS: 1
 
   # - name: coverage
   #   image: node:16-alpine
@@ -75,6 +62,8 @@ steps:
     when:
       event:
         - push
+      branch:
+        exclude: [prod]
     depends_on:
       - build
     commands:
@@ -92,6 +81,8 @@ steps:
     when:
       event:
         - push
+      branch:
+        exclude: [prod]
     depends_on:
       - build
     commands:
@@ -116,7 +107,6 @@ steps:
       status: success
     depends_on:
       - lint
-      # - test
       - cypress
       - build
     settings:
@@ -167,6 +157,4 @@ volumes:
 
 ---
 kind: signature
-hmac: a87c2dbaf34e697a6a4850e33bbb1768086b0982d91a7aad1e92f85b10f4b4dd
-
-...
+hmac: 0aae33caf8b82ea0895715cb844b6c58dc67c3a3b0c909ada1035ecd941908aa


### PR DESCRIPTION
We only perform tests when they are merged into master, pushing to prod should only perform deployment :eyes: