### PR TITLE
changed command used in deployment README to be correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ sudo google-chrome
 2. Add your user to the `dialout` group.
    - Check what group the tty(USBPORT) is:
    ```
-   $ ls -al /dev/ttyUSB* | cut -d ' ' -f 2`
+   $ ls -al /dev/ttyUSB* | cut -d ' ' -f 2
    ```
    - Check what groups your user is added to:
    ```sh
@@ -114,7 +114,7 @@ $ sudo google-chrome
    ```
    - Normally the `tty` is in the `dialout` group, so add your user to that group with:
    ```sh
-   $ sudo usrmod -a -G dialout $USER
+   $ sudo usermod -a -G dialout $USER
    ```
 
 > You need to sign in and out to get the new privileges!

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -27,7 +27,7 @@ The vote-CLI allows you to create **admin**, **moderator** and **normal** users.
 
 ```bash
 # Replace <username> with the username, and <card-key> with a random value
-$ docker-compose exec vote ./bin/users create-user <username> <card-key>
+$ docker exec -it vote ./bin/users create-user <username> <card-key>
 
 # You will then be promted to select the type of user you want to create
 Usermode:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -27,7 +27,7 @@ The vote-CLI allows you to create **admin**, **moderator** and **normal** users.
 
 ```bash
 # Replace <username> with the username, and <card-key> with a random value
-$ docker exec -it vote ./bin/users create-user <username> <card-key>
+$ docker exec -i vote ./bin/users create-user <username> <card-key>
 
 # You will then be promted to select the type of user you want to create
 Usermode:


### PR DESCRIPTION
Old docs said use docker-compose which is no longer in use. The correct usage is docker exec.
Old create-user docs did not include docker exec -i such that input was not possible.

For making card scanner on linux fixed som minor spelling mistakes.