### PR TITLE
more clear commands and make it clearer how the device is names

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ $ sudo google-chrome
 **OR**
 
 2. Add your user to the `dialout` group.
-   - Check what group the tty(USBPORT) is:
+   - Check what group the USB device is (has the form /tty/USB...):
    ```
-   $ ls -al /dev/ttyUSB* | cut -d ' ' -f 2
+   $ ls -al /dev/ttyUSB*
    ```
    - Check what groups your user is added to:
    ```sh


### PR DESCRIPTION
New command more concise output:
ls -al /dev/ttyUSB*

Make it clear what device and its name SHOULD look like
Check what group the USB device is (has the form /tty/USB...)
